### PR TITLE
PHX-127 Store tokenized payment method in Omni

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/InitParams.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/InitParams.kt
@@ -3,8 +3,17 @@ package com.fattmerchant.android
 import android.content.Context
 import com.fattmerchant.omni.networking.OmniApi
 
+/** Contains all the data necessary to initialize [Omni] */
 data class InitParams(
+    /** The [Context] of your app*/
     var appContext: Context,
+
+    /** An ephemeral Omni api key*/
     var apiKey: String,
-    var environment: OmniApi.Environment = OmniApi.Environment.LIVE
+
+    /** The Omni environment to use*/
+    var environment: OmniApi.Environment = OmniApi.Environment.LIVE,
+
+    /** An id for your application */
+    var appId: String = "appid"
 )

--- a/cardpresent/src/main/java/com/fattmerchant/android/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/Omni.kt
@@ -33,7 +33,7 @@ class Omni(omniApi: OmniApi) : CommonOmni(omniApi) {
                 "apiKey" to params.apiKey,
                 "appContext" to params.appContext,
                 "environment" to params.environment,
-                "appId" to "sampleapp123"
+                "appId" to params.appId
             )
 
             initialize(paramMap, completion, error)

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -228,6 +228,10 @@ class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
             cardHolderLastName = lastName
             cardType = result[ParameterKeys.CardSchemeId]?.toLowerCase()
             success = result[ParameterKeys.TransactionResult] == ParameterValues.Approved
+
+            result[ParameterKeys.CustomerVaultId]?.let { token ->
+                paymentToken = "nmi_$token"
+            }
         }
     }
 

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -152,7 +152,7 @@ class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
     }
 
     override suspend fun performTransaction(request: TransactionRequest): TransactionResult {
-        val paymentRequestParams = mapTransactionRequestToParams(request)
+        val paymentRequestParams = Parameters().withTransactionRequest(request)
 
         val result = suspendCancellableCoroutine<Parameters> { cont ->
 
@@ -302,38 +302,4 @@ class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
         return availablePinPadsList
     }
 
-    companion object {
-
-        /**
-         * Gets the User Reference from the given [Transaction]
-         *
-         * @param transaction
-         * @return a string containing the user reference or null if not found
-         */
-        private fun extractUserReference(transaction: Transaction): String? =
-            (transaction.meta as? Map<*, *>)?.get("nmiUserRef") as? String
-
-        /**
-         * Generates a user reference for chipDNA transactions
-         *
-         * @return String containing the generated user reference
-         */
-        private fun generateUserReference(): String =
-            String.format("CDM-%s", SimpleDateFormat("yy-MM-dd-HH.mm.ss", Locale.US).format(Date()))
-
-        /**
-         * Converts a [TransactionRequest] into a [Parameters] object that ChipDNA understands
-         *
-         * @param request
-         */
-        private fun mapTransactionRequestToParams(request: TransactionRequest) = Parameters().apply {
-            add(ParameterKeys.Amount, request.amount.centsString())
-            add(ParameterKeys.AmountType, ParameterValues.AmountTypeActual)
-            add(ParameterKeys.Currency, "USD")
-            add(ParameterKeys.UserReference, generateUserReference())
-            add(ParameterKeys.PaymentMethod, ParameterValues.Card)
-            add(ParameterKeys.AutoConfirm, ParameterValues.TRUE)
-            add(ParameterKeys.TransactionType, ParameterValues.Sale)
-        }
-    }
 }

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
@@ -1,8 +1,14 @@
 package com.fattmerchant.android.chipdna
 
+import com.creditcall.chipdnamobile.ParameterKeys
+import com.creditcall.chipdnamobile.ParameterValues
 import com.creditcall.chipdnamobile.Parameters
 import com.fattmerchant.android.chipdna.ChipDnaDriver
 import com.fattmerchant.omni.data.MobileReader
+import com.fattmerchant.omni.data.TransactionRequest
+import com.fattmerchant.omni.data.models.Transaction
+import java.text.SimpleDateFormat
+import java.util.*
 
 /**
  * Makes an instance of [MobileReader] for the given [pinPad]
@@ -22,3 +28,41 @@ fun mapPinPadToMobileReader(pinPad: ChipDnaDriver.SelectablePinPad): MobileReade
  * @return null if not found
  */
 operator fun Parameters?.get(key: String): String? = this?.getValue(key)
+
+/**
+ * The param value to make NMI add a customer to the customer vault
+ *
+ * This should be used with the ParameterKeys.CustomerVaultCommand and passed into startTransaction()
+ */
+val ParameterValuesAddCustomer = "add-customer"
+
+/**
+ * Gets the User Reference from the given [Transaction]
+ *
+ * @param transaction
+ * @return a string containing the user reference or null if not found
+ */
+internal fun extractUserReference(transaction: Transaction): String? =
+        (transaction.meta as? Map<*, *>)?.get("nmiUserRef") as? String
+
+/**
+ * Generates a user reference for chipDNA transactions
+ *
+ * @return String containing the generated user reference
+ */
+internal fun generateUserReference(): String =
+        String.format("CDM-%s", SimpleDateFormat("yy-MM-dd-HH.mm.ss", Locale.US).format(Date()))
+
+internal fun Parameters.withTransactionRequest(request: TransactionRequest) = Parameters().apply {
+    add(ParameterKeys.Amount, request.amount.centsString())
+    add(ParameterKeys.AmountType, ParameterValues.AmountTypeActual)
+    add(ParameterKeys.Currency, "USD")
+    add(ParameterKeys.UserReference, generateUserReference())
+    add(ParameterKeys.PaymentMethod, ParameterValues.Card)
+    add(ParameterKeys.AutoConfirm, ParameterValues.TRUE)
+    add(ParameterKeys.TransactionType, ParameterValues.Sale)
+
+    if (request.tokenize) {
+        add(ParameterKeys.CustomerVaultCommand, ParameterValuesAddCustomer)
+    }
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
@@ -6,5 +6,19 @@ package com.fattmerchant.omni.data
  * Has all necessary information to perform a transaction
  */
 data class TransactionRequest(
-    val amount: Amount
-)
+    /** The [Amount] to be collected during the transaction */
+    val amount: Amount,
+
+    /** The option to tokenize the payment method for later usage */
+    val tokenize: Boolean = true
+) {
+
+    /**
+     * Initializes a Transaction with the given amount
+     *
+     * Note that this will request tokenization
+     *
+     * @param amount The [Amount] to be collected during the transaction
+     * */
+    constructor(amount: Amount) : this(amount, true)
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionResult.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionResult.kt
@@ -43,4 +43,7 @@ open class TransactionResult {
     /** A user-defined string used to refer to the transaction */
     var userReference: String? = null
 
+    /** The token that represents this payment method */
+    internal var paymentToken: String? = null
+
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/PaymentMethod.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/PaymentMethod.kt
@@ -32,6 +32,27 @@ open class PaymentMethod : Model {
     open var personName: String? = null
     open var purgedAt: String? = null
     open var spreedlyToken: String? = null
-    open var tokenize: Boolean? = null
     open var updatedAt: String? = null
+
+    /**
+     * Whether or not Omni should tokenize this PaymentMethod
+     *
+     * @note If this field is true, `paymentToken` must be `null`
+     */
+    open var tokenize: Boolean? = null
+
+    /**
+     * The token that represents this payment method
+     *
+     * The only use-case for this field is storing the token within Omni.
+     * After cardpresent tokenization, we can create a PaymentMethod using this class.
+     * If we include the paymentToken, then we can later store it as an already-tokenized
+     * PaymentMethod
+     *
+     * Omni performs transactions with this token. Therefore, it is crucial that only the actual
+     * payment token be placed here
+     *
+     * @note If this field is not `null`, then `tokenize` must be `false`
+     */
+    internal var paymentToken: String? = null
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/networking/OmniApi.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/networking/OmniApi.kt
@@ -112,8 +112,18 @@ class OmniApi {
      * @param paymentMethod
      * @return the created payment method
      */
-    suspend fun createPaymentMethod(paymentMethod: PaymentMethod, error: (Error) -> Unit): PaymentMethod? =
-        post("payment-method", JsonParser.toJson(paymentMethod), error)
+    suspend fun createPaymentMethod(paymentMethod: PaymentMethod, error: (Error) -> Unit): PaymentMethod? {
+        // If the payment method is already tokenized, use the payment-method/token route
+        // that allows us to pass the token to Omni
+        val url = if (paymentMethod.paymentToken != null) {
+            "payment-method/token"
+        } else {
+            "payment-method"
+        }
+
+        return post(url, JsonParser.toJson(paymentMethod), error)
+    }
+
 
     private suspend inline fun <reified T> post(urlString: String, body: String, error: (Error) -> Unit): T? =
         this.request<T>(

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
@@ -80,6 +80,7 @@ class TakeMobileReaderPayment(
                 this.cardLastFour = cardLastFour
                 personName = (customer.firstname ?: "") + " " + (customer.lastname ?: "")
                 tokenize = false
+                paymentToken = result.paymentToken
             }
         ) {
             onError(it)

--- a/cardpresent/src/test/java/com/fattmerchant/omni/chipdna/ChipDnaUtilsTest.kt
+++ b/cardpresent/src/test/java/com/fattmerchant/omni/chipdna/ChipDnaUtilsTest.kt
@@ -1,0 +1,44 @@
+package com.fattmerchant.omni.chipdna
+
+
+import com.creditcall.chipdnamobile.ParameterKeys
+import com.creditcall.chipdnamobile.Parameters
+import com.fattmerchant.android.chipdna.extractUserReference
+import com.fattmerchant.android.chipdna.withTransactionRequest
+import com.fattmerchant.omni.data.Amount
+import com.fattmerchant.omni.data.TransactionRequest
+import com.fattmerchant.omni.data.models.Transaction
+import junit.framework.Assert.assertFalse
+import org.junit.Test
+
+class ChipDnaUtilsTest {
+
+    private val amount = Amount(cents = 10)
+
+    @Test
+    fun `adds customer vault request parameter if tokenization requested`() {
+        val request = TransactionRequest(amount)
+        val params = Parameters().withTransactionRequest(request)
+        assert(params.containsKey(ParameterKeys.CustomerVaultCommand))
+    }
+
+    @Test
+    fun `does not add customer vault request parameter if tokenization not requested`() {
+        val request = TransactionRequest(amount, false)
+        val params = Parameters().withTransactionRequest(request)
+        assertFalse(params.containsKey(ParameterKeys.CustomerVaultCommand))
+    }
+
+    @Test
+    fun `can extract user reference from transaction`() {
+        val userRef = "gotcha!"
+        val transaction = Transaction().apply {
+            meta = mapOf(
+                    "nmiUserRef" to userRef
+            )
+        }
+
+        assert(extractUserReference(transaction) == userRef)
+    }
+
+}

--- a/cardpresent/src/test/java/com/fattmerchant/omni/data/TransactionRequestTests.kt
+++ b/cardpresent/src/test/java/com/fattmerchant/omni/data/TransactionRequestTests.kt
@@ -1,0 +1,21 @@
+package com.fattmerchant.omni.data
+
+import org.junit.Test
+
+class TransactionRequestTests {
+
+    @Test
+    fun `transaction request defaults to tokenization enabled`() {
+        // Create a TransactionRequest but don't pass in tokenization
+        val request = TransactionRequest(Amount(10))
+        assert(request.tokenize)
+    }
+
+    @Test
+    fun `can initialize with or without tokenize param`() {
+        TransactionRequest(Amount(10), true)
+        TransactionRequest(Amount(10))
+        assert(true)
+    }
+
+}


### PR DESCRIPTION
## What is this?
We can now get the token for the payment method from NMI, so now we need that stored in Omni so we can use that payment method from other Omni products. This specific feature covers the injection of the token into Omni

## What did I do?
- Modified the `TransactionResult`, and `PaymentMethod` objects to be aware of `paymentToken`
- Made `ChipDnaDriver` pass the `paymentToken` to the `TransactionResult`
- Made `TakeMobileReaderPaymentTransaction` use the `/payment-method/token` route, which stores the token along with the payment method
