### PR TITLE
PHX-128 Store transaction id for future linkedRefunds

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -224,6 +224,8 @@ class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
             authCode = result[ParameterKeys.AuthCode]
             maskedPan = result[ParameterKeys.MaskedPan] ?: ""
             userReference = result[ParameterKeys.UserReference]
+            localId = result[ParameterKeys.CardEaseReference]
+            externalId = result[ParameterKeys.TransactionId]
             cardHolderFirstName = firstName
             cardHolderLastName = lastName
             cardType = result[ParameterKeys.CardSchemeId]?.toLowerCase()

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionResult.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionResult.kt
@@ -43,4 +43,18 @@ open class TransactionResult {
     /** A user-defined string used to refer to the transaction */
     var userReference: String? = null
 
+    /**
+     * The ID of this transaction in the local database
+     *
+     * For example, in the case of NMI, this would be the CardEaseReferenceId
+     */
+    var localId: String? = null
+
+    /**
+     * The ID of this transaction in the 3rd party responsible for performing it.
+     *
+     * For example, in the case of NMI, this would be the TransactionID
+     */
+    var externalId: String? = null
+
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
@@ -20,6 +20,26 @@ class TakeMobileReaderPayment(
     class TakeMobileReaderPaymentException(message: String? = null) :
         OmniException("Could not take mobile reader payment", message)
 
+    companion object {
+        internal fun transactionMetaFrom(result: TransactionResult): Map<String, Any> {
+            val transactionMeta = mutableMapOf<String, Any>()
+
+            result.userReference?.let {
+                transactionMeta["nmiUserRef"] = it
+            }
+
+            result.localId?.let {
+                transactionMeta["cardEaseReference"] = it
+            }
+
+            result.externalId?.let {
+                transactionMeta["nmiTransactionId"] = it
+            }
+
+            return transactionMeta
+        }
+    }
+
     suspend fun start(onError: (OmniException) -> Unit): Transaction? = coroutineScope {
 
         // Get the reader responsible for taking the payment
@@ -95,8 +115,7 @@ class TakeMobileReaderPayment(
         } ?: return@coroutineScope null
 
         // Create transaction
-        val transactionMeta = mutableMapOf<String, Any>()
-        transactionMeta["nmiUserRef"] = result.userReference ?: ""
+        val transactionMeta = transactionMetaFrom(result)
 
         var gatewayResponse: Map<String, Any>? = null
 

--- a/cardpresent/src/test/java/com/fattmerchant/omni/usecase/TakeMobileReaderPaymentTest.kt
+++ b/cardpresent/src/test/java/com/fattmerchant/omni/usecase/TakeMobileReaderPaymentTest.kt
@@ -1,0 +1,22 @@
+package com.fattmerchant.omni.usecase
+
+import com.fattmerchant.omni.data.TransactionResult
+import org.junit.Test
+
+class TakeMobileReaderPaymentTest {
+
+    @Test
+    fun `properly adds nmi fields to meta from TransactionResult`() {
+        val transactionResult = TransactionResult().apply {
+            localId = "localId"
+            externalId = "externalId"
+            userReference = "userRef"
+        }
+
+        val meta = TakeMobileReaderPayment.transactionMetaFrom(transactionResult)
+
+        assert(meta["nmiUserRef"] == "userRef")
+        assert(meta["cardEaseReference"] == "localId")
+        assert(meta["nmiTransactionId"] == "externalId")
+    }
+}


### PR DESCRIPTION
## What is this
In order to do linkedRefunds from Omni Gateway, we need to be able to reference a transaction by the id that NMI will recognize

## What did I do
* Started recording the transaction id that NMI gives us in a TransactionResult.externalId
* started recording the CardEaseReference to TransactionResult.localId
* Added documentation explaining what they both are