### PR TITLE
[PHX-401] Add transaction token to transactions

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/Transaction.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/Transaction.kt
@@ -37,7 +37,7 @@ open class Transaction : Model {
     open var source: String? = null
     open var sourceIp: String? = null
     open var response: Any? = null
-    open var spreedlyToken: String? = null
+    open var token: String? = null
     open var success: Boolean? = null
     open var total: String? = null
     open var totalRefunded: String? = null

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
@@ -145,6 +145,7 @@ class TakeMobileReaderPayment(
                 customerId = customer.id
                 invoiceId = invoice.id
                 response = gatewayResponse
+                token = result.externalId
             }
         ) {
             onError(it)


### PR DESCRIPTION
## What is this?
In order for Omni to be be able to refund a transaction done using the CPSDK, we need to tell Omni the id of that transaction. Omni will require that we pass this in as a token when we POST the transaction.

## What did I do?
Added the token field to the Transaction model
Made ChipDna transactions put the token in the Transaction model