### PR TITLE
[MOB-1] Show Mobile Reader Connection Status

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
@@ -1,5 +1,6 @@
 package com.fattmerchant.android.chipdna
 
+import android.bluetooth.BluetoothClass
 import com.creditcall.chipdnamobile.DeviceStatus
 import com.creditcall.chipdnamobile.ParameterKeys
 import com.creditcall.chipdnamobile.ParameterValues
@@ -9,6 +10,7 @@ import com.fattmerchant.android.chipdna.ChipDnaDriver
 import com.fattmerchant.omni.data.MobileReader
 import com.fattmerchant.omni.data.TransactionRequest
 import com.fattmerchant.omni.data.TransactionUpdate
+import com.fattmerchant.omni.data.models.MobileReaderConnectionStatus
 import com.fattmerchant.omni.data.models.Transaction
 import java.text.SimpleDateFormat
 import java.util.*
@@ -123,4 +125,34 @@ internal fun Parameters.withTransactionRequest(request: TransactionRequest) = Pa
     if (request.tokenize) {
         add(ParameterKeys.CustomerVaultCommand, ParameterValuesAddCustomer)
     }
+}
+
+/**
+ * Initializes a `MobileReaderConnectionStatus` object from the given ChipDnaConfigurationUpdate
+ *
+ * ChipDna hands us a ton of configuration updates during the mobile reader connection process
+ * The ones we care about are:
+ *  - Connecting
+ *  - Permorming Tms Update
+ *  - Updating Pinpad Firmware
+ *  - Rebooting
+ *  - Registering
+ *
+ * @param chipDnaConfigurationUpdate
+ */
+fun MobileReaderConnectionStatus.Companion.from(chipDnaConfigurationUpdate: String): MobileReaderConnectionStatus? = when(chipDnaConfigurationUpdate) {
+    ParameterValues.Connecting -> MobileReaderConnectionStatus.CONNECTING
+
+    ParameterValues.UpdatingPinPadFirmware,
+    ParameterValues.PerformingTmsUpdate,
+    ParameterValues.Registering -> MobileReaderConnectionStatus.UPDATING
+
+    ParameterValues.RebootingPinPad -> MobileReaderConnectionStatus.REBOOTING
+
+    else -> null
+}
+
+fun MobileReaderConnectionStatus.Companion.from(chipDnaDeviceStatus: DeviceStatus.DeviceStatusEnum) = when(chipDnaDeviceStatus) {
+    DeviceStatus.DeviceStatusEnum.DeviceStatusDisconnected -> MobileReaderConnectionStatus.DISCONNECTED
+    else -> null
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/MobileReaderConnectionStatusListener.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/MobileReaderConnectionStatusListener.kt
@@ -1,0 +1,13 @@
+package com.fattmerchant.omni
+
+import com.fattmerchant.omni.data.models.MobileReaderConnectionStatus
+
+interface MobileReaderConnectionStatusListener {
+
+    /**
+     * Called when [MobileReader] has a new [MobileReaderConnectionStatus]
+     *
+     * @param status the new [MobileReaderConnectionStatus] of the [MobileReader]
+     */
+    fun mobileReaderConnectionStatusUpdate(status: MobileReaderConnectionStatus)
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -35,6 +35,9 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
     /** Receives notifications about transaction events such as when a card is swiped */
     open var transactionUpdateListener: TransactionUpdateListener? = null
 
+    /** Receives notifications about reader connection events */
+    open var mobileReaderConnectionStatusListener: MobileReaderConnectionStatusListener? = null
+
     internal open lateinit var mobileReaderDriverRepository: MobileReaderDriverRepository
     internal var coroutineScope = MainScope()
     private var currentJob: CoroutineScope? = null
@@ -90,7 +93,8 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
                 val connected = ConnectMobileReader(
                         coroutineContext,
                         mobileReaderDriverRepository,
-                        mobileReader
+                        mobileReader,
+                        mobileReaderConnectionStatusListener
                 ).start()
 
                 if (connected) {

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/MobileReaderDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/MobileReaderDriver.kt
@@ -1,5 +1,6 @@
 package com.fattmerchant.omni.data
 
+import com.fattmerchant.omni.MobileReaderConnectionStatusListener
 import com.fattmerchant.omni.SignatureProviding
 import com.fattmerchant.omni.TransactionUpdateListener
 import com.fattmerchant.omni.data.models.OmniException
@@ -24,6 +25,8 @@ internal interface MobileReaderDriver {
 
     /** A list of serial numbers that this driver has previously connected to */
     var familiarSerialNumbers: MutableList<String>
+
+    var mobileReaderConnectionStatusListener: MobileReaderConnectionStatusListener?
 
     /**
      * Whether or not the given [MobileReaderDriver] is ready to take payment

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/MobileReaderConnectionStatus.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/MobileReaderConnectionStatus.kt
@@ -1,25 +1,23 @@
 package com.fattmerchant.omni.data.models
 
 /** The status of a {MobileReader} */
-class MobileReaderConnectionStatus {
+enum class MobileReaderConnectionStatus(val status: String) {
+    /** The reader has been found by the Android device and is currently being connected */
+    CONNECTING("connecting"),
 
-    companion object {
-        /** The reader has been found by the Android device and is currently being connected */
-        val connecting: String = "connecting"
+    /** The reader is connected */
+    CONNECTED("connected"),
 
-        /** The reader is connected */
-        val connected: String = ""
+    /** The reader is disconnected */
+    DISCONNECTED("disconnected"),
 
-        /** The reader is disconnected */
-        val disconnected: String = ""
+    /** The reader is performing an update
+     * - Note: This might be a long-running operation
+     */
+    UPDATING("updating"),
 
-        /** The reader is performing an update
-         * - Note: This might be a long-running operation
-         */
-        val updating: String = ""
+    /** The reader is performing a reboot */
+    REBOOTING("rebooting");
 
-        /** The reader is performing a reboot */
-        val rebooting: String = ""
-    }
-
+    companion object { }
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/MobileReaderConnectionStatus.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/MobileReaderConnectionStatus.kt
@@ -1,0 +1,25 @@
+package com.fattmerchant.omni.data.models
+
+/** The status of a {MobileReader} */
+class MobileReaderConnectionStatus {
+
+    companion object {
+        /** The reader has been found by the Android device and is currently being connected */
+        val connecting: String = "connecting"
+
+        /** The reader is connected */
+        val connected: String = ""
+
+        /** The reader is disconnected */
+        val disconnected: String = ""
+
+        /** The reader is performing an update
+         * - Note: This might be a long-running operation
+         */
+        val updating: String = ""
+
+        /** The reader is performing a reboot */
+        val rebooting: String = ""
+    }
+
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/ConnectMobileReader.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/ConnectMobileReader.kt
@@ -1,5 +1,6 @@
 package com.fattmerchant.omni.usecase
 
+import com.fattmerchant.omni.MobileReaderConnectionStatusListener
 import com.fattmerchant.omni.data.MobileReader
 import com.fattmerchant.omni.data.models.OmniException
 import com.fattmerchant.omni.data.repository.MobileReaderDriverRepository
@@ -12,15 +13,16 @@ import kotlin.coroutines.CoroutineContext
 internal class ConnectMobileReader(
     override val coroutineContext: CoroutineContext,
     var mobileReaderDriverRepository: MobileReaderDriverRepository,
-    var mobileReader: MobileReader
+    var mobileReader: MobileReader,
+    var mobileReaderConnectionStatusListener: MobileReaderConnectionStatusListener? = null
 ) : CoroutineScope {
 
     suspend fun start(): Boolean {
         return try {
-            mobileReaderDriverRepository
-                .getDriverFor(mobileReader)
-                ?.connectReader(mobileReader)
-                ?: false
+            return mobileReaderDriverRepository.getDriverFor(mobileReader)?.let { driver ->
+                driver.mobileReaderConnectionStatusListener = mobileReaderConnectionStatusListener
+                driver.connectReader(mobileReader)
+            } ?: false
         } catch (e: OmniException) {
             false
         }


### PR DESCRIPTION
## What is this
When connecting to a mobile reader, there is no idea of what is happening from the moment that you call omni.connect(reader:completion:error:) to the moment that you hit the completion or the error block. However, the mobile reader is typically doing a ton of work during this time. Work that includes:

- Actually connecting the BT reader
- Making sure the BT reader can be used on behalf of the merchant
- Maybe doing a firmware update
- Maybe doing a TMS update
- Maybe rebooting
- Etc.

Another big problem is not knowing when a mobile reader disconnects by itself. If a mobile reader dies or is idle for too long, then it might disconnect itself from the iOS device. But prior to this PR, there is no way to listen for the disconnect event to allow the user to reconnect the mobile reader.

## What did I do
I created a MobileReaderConnectionStatus enum that shows all the states that the mobile reader can be in, and I created a MobileReaderConnectionStatusDelegate that emits a MobileReaderConnectionStatus every time there something changes with the status of the reader.