### PR TITLE
[SPRINT-143] [MOB-61] Get mobile reader settings from new route in gateway

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -9,6 +9,7 @@ import com.fattmerchant.omni.data.*
 import com.fattmerchant.omni.data.models.Merchant
 import com.fattmerchant.omni.data.models.Transaction
 import com.fattmerchant.omni.data.MobileReaderDriver.*
+import com.fattmerchant.omni.data.models.MobileReaderDetails
 import com.fattmerchant.omni.data.models.OmniException
 import kotlinx.coroutines.*
 import org.xmlpull.v1.XmlPullParserException
@@ -92,11 +93,10 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
         val appId = args["appId"] as? String
             ?: throw InitializeMobileReaderDriverException("appId not found")
 
-        val merchant = args["merchant"] as? Merchant
-            ?: throw InitializeMobileReaderDriverException("merchant not found")
+        val nmiDetails = args["nmi"] as? MobileReaderDetails.NMIDetails
+            ?: throw InitializeMobileReaderDriverException("nmi details not found")
 
-        val apiKey = merchant.emvPassword()
-            ?: throw InitializeMobileReaderDriverException("emvTerminalSecret not found")
+        val apiKey = nmiDetails.securityKey
 
         val params = Parameters().apply {
             add(ParameterKeys.Password, "password")

--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -64,17 +64,19 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
                 error(OmniException("Could not get reader settings", it.message))
             } ?: return@launch
 
+            val mutatedArgs = args.toMutableMap()
+
             if(mobileReaderDetails.nmi != null) {
-                args.toMutableMap()["nmi"] = mobileReaderDetails.nmi!!
+                mutatedArgs["nmi"] = mobileReaderDetails.nmi!!
             }
 
             if(mobileReaderDetails.anywhereCommerce != null) {
-                args.toMutableMap()["awc"] = mobileReaderDetails.anywhereCommerce!!
+                mutatedArgs["awc"] = mobileReaderDetails.anywhereCommerce!!
             }
 
             InitializeDrivers(
                     mobileReaderDriverRepository,
-                    args,
+                    mutatedArgs,
                     coroutineContext
             ).start(error)
 

--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -66,12 +66,12 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
 
             val mutatedArgs = args.toMutableMap()
 
-            if(mobileReaderDetails.nmi != null) {
-                mutatedArgs["nmi"] = mobileReaderDetails.nmi!!
+            mobileReaderDetails.nmi?.let {
+                mutatedArgs["nmi"] = it
             }
 
-            if(mobileReaderDetails.anywhereCommerce != null) {
-                mutatedArgs["awc"] = mobileReaderDetails.anywhereCommerce!!
+            mobileReaderDetails.anywhereCommerce?.let {
+                mutatedArgs["awc"] = it
             }
 
             InitializeDrivers(

--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -59,19 +59,22 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
      */
     internal fun initialize(args: Map<String, Any>, completion: () -> Unit, error: (OmniException) -> Unit) {
         coroutineScope.launch {
-            // Verify that the apiKey corresponds to a real merchant
-            val merchant = omniApi.getMerchant {
-                error(OmniException("Could not initialize Omni", it.message))
+
+            val mobileReaderDetails = omniApi.getMobileReaderSettings {
+                error(OmniException("Could not get reader settings", it.message))
             } ?: return@launch
 
-            // Get the nmiApiKey from the merchant
-            val argsWithMerchant = args.toMutableMap().apply {
-                set("merchant", merchant)
+            if(mobileReaderDetails.nmi != null) {
+                args.toMutableMap()["nmi"] = mobileReaderDetails.nmi!!
+            }
+
+            if(mobileReaderDetails.anywhereCommerce != null) {
+                args.toMutableMap()["awc"] = mobileReaderDetails.anywhereCommerce!!
             }
 
             InitializeDrivers(
                     mobileReaderDriverRepository,
-                    argsWithMerchant,
+                    args,
                     coroutineContext
             ).start(error)
 

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/MobileReaderDetails.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/MobileReaderDetails.kt
@@ -1,0 +1,17 @@
+package com.fattmerchant.omni.data.models
+
+open class MobileReaderDetails: Model {
+    override var id: String? = null
+    open var anywhereCommerce: AWCDetails? = null
+    open var nmi: NMIDetails? = null
+
+    class AWCDetails {
+        var terminalId: String = ""
+        var terminalSecret: String = ""
+    }
+
+    class NMIDetails {
+        var securityKey: String = ""
+    }
+}
+

--- a/cardpresent/src/main/java/com/fattmerchant/omni/networking/OmniApi.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/networking/OmniApi.kt
@@ -47,6 +47,14 @@ class OmniApi {
     internal suspend fun getSelf(error: (Error) -> Unit): Self? = get("self", error)
 
     /**
+     * Gets the mobile reader settings which the [token] corresponds to
+     *
+     * @param error
+     * @return
+     */
+    internal suspend fun getMobileReaderSettings(error: (Error) -> Unit): MobileReaderDetails? = get("team/gateway/hardware/mobile", error)
+
+    /**
      * Gets the merchant which the [token] corresponds to
      *
      * @param error


### PR DESCRIPTION
## What is this
We are now getting the mobile reader settings from a new route: team/gateway/hardware/mobile instead of passing along that data from the merchant object.

## What did I do
Instead of passing the merchant object along to the drivers, I pass the retrieved mobile reader details. This is the same for both NMI and AWC readers.