### PR TITLE
[SPRINT-144][MOB-70] Support catalog items

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
@@ -1,5 +1,7 @@
 package com.fattmerchant.omni.data
 
+import com.fattmerchant.omni.data.models.CatalogItem
+
 /**
  * A request for a transaction
  *
@@ -10,7 +12,9 @@ data class TransactionRequest(
     val amount: Amount,
 
     /** The option to tokenize the payment method for later usage */
-    val tokenize: Boolean = true
+    val tokenize: Boolean = true,
+
+    val lineItems: List<CatalogItem>? = listOf()
 ) {
 
     /**
@@ -21,4 +25,14 @@ data class TransactionRequest(
      * @param amount The [Amount] to be collected during the transaction
      * */
     constructor(amount: Amount) : this(amount, true)
+
+    /**
+     * Initializes a Transaction with the given amount and list of catalog items
+     *
+     * Note that this will request tokenization
+     *
+     * @param amount The [Amount] to be collected during the transaction
+     * @param lineItems The [CatalogItem]s to be added to the transaction
+     * */
+    constructor(amount: Amount, lineItems: List<CatalogItem>?) : this(amount, true, lineItems)
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/CatalogItem.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/CatalogItem.kt
@@ -1,0 +1,10 @@
+package com.fattmerchant.omni.data.models
+
+open class CatalogItem: Model {
+    override var id: String? = null
+
+    open var item: String? = null
+    open var details: String? = null
+    open var quantity: Int = 1
+    open var price: Double = 0.0
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
@@ -40,6 +40,10 @@ internal class TakeMobileReaderPayment(
                 transactionMeta["nmiTransactionId"] = it
             }
 
+            result.request?.lineItems?.let {
+                transactionMeta["lineItems"] = it
+            }
+
             return transactionMeta
         }
     }

--- a/cardpresent/src/test/java/com/fattmerchant/omni/usecase/InitializeDriversTest.kt
+++ b/cardpresent/src/test/java/com/fattmerchant/omni/usecase/InitializeDriversTest.kt
@@ -19,20 +19,21 @@ class InitializeDriversTest {
     private val mainThreadSurrogate = newSingleThreadContext("UI thread")
     private val scope = GlobalScope
 
-    val mockMobileReaderDriverRepository = object: MobileReaderDriverRepository {
-
-        override suspend fun getDriverFor(transaction: Transaction): MobileReaderDriver? {
-            return null
-        }
-
-        override suspend fun getDriverFor(mobileReader: MobileReader): MobileReaderDriver? {
-            return null
-        }
-
-        override suspend fun getDrivers(): List<MobileReaderDriver> {
-            return listOf()
-        }
-    }
+    //TODO: Build out mock mobile reader support for testing - Hassan
+//    val mockMobileReaderDriverRepository = object: MobileReaderDriverRepository {
+//
+//        override suspend fun getDriverFor(transaction: Transaction): MobileReaderDriver? {
+//            return null
+//        }
+//
+//        override suspend fun getDriverFor(mobileReader: MobileReader): MobileReaderDriver? {
+//            return null
+//        }
+//
+//        override suspend fun getDrivers(): List<MobileReaderDriver> {
+//            return listOf()
+//        }
+//    }
 
 
 }

--- a/cardpresent/src/test/java/com/fattmerchant/omni/usecase/TakeMobileReaderPaymentTest.kt
+++ b/cardpresent/src/test/java/com/fattmerchant/omni/usecase/TakeMobileReaderPaymentTest.kt
@@ -1,6 +1,12 @@
 package com.fattmerchant.omni.usecase
 
+import com.fattmerchant.omni.data.Amount
+import com.fattmerchant.omni.data.TransactionRequest
 import com.fattmerchant.omni.data.TransactionResult
+import com.fattmerchant.omni.data.models.CatalogItem
+import kotlinx.serialization.ImplicitReflectionSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.stringify
 import org.junit.Test
 
 class TakeMobileReaderPaymentTest {
@@ -18,5 +24,42 @@ class TakeMobileReaderPaymentTest {
         assert(meta["nmiUserRef"] == "userRef")
         assert(meta["cardEaseReference"] == "localId")
         assert(meta["nmiTransactionId"] == "externalId")
+    }
+
+    @Test
+    fun `properly adds catalog items to meta from TransactionResult`() {
+        val testItem1 = CatalogItem().apply {
+            id = "fakeid1"
+            item = "Test Item 1"
+            details = "The first test item."
+            quantity = 1
+            price = 0.1
+        }
+
+        val testItem2 = CatalogItem().apply {
+            id = "fakeid2"
+            item = "Test Item 2"
+            details = "The second test item."
+            quantity = 2
+            price = 0.1
+        }
+
+        val testItems = listOf(testItem1, testItem2)
+
+        val expectedMeta = mutableMapOf<String, Any>()
+
+        testItems.let {
+            expectedMeta["lineItems"] = it
+        }
+
+        val transactionRequest = TransactionRequest(Amount(cents = 3), testItems)
+
+        val transactionResult = TransactionResult().apply {
+            request = transactionRequest
+        }
+
+        val meta = TakeMobileReaderPayment.transactionMetaFrom(transactionResult)
+
+        assert(meta["lineItems"] == expectedMeta["lineItems"])
     }
 }


### PR DESCRIPTION
## What is this
This adds support in the SDK for the ability to provide a list of catalog items to a transaction request. It uses the `meta` field in the `TransactionRequest` to pass to the Omni API.

## What did I do
Added a new model object called `CatalogItem` which maps the object passed to the `meta` field.
Added `lineItems` list to the `TransactionRequest` and created a public constructor to support the new field.
Added a new dictionary item to the meta data being passed in the use case of `TakeMobileReaderPayment` that contains the encoded line items.
Wrote a test case to validate the metadata is properly formed in the `TransactionRequest`.