### PR TITLE
[SPRINT-144][MOB-4] Support refunds across CP SDK devices

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/anywherecommerce/AWCDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/anywherecommerce/AWCDriver.kt
@@ -42,6 +42,10 @@ internal class AWCDriver: MobileReaderDriver {
         return false
     }
 
+    override suspend fun isOmniRefundsSupported(): Boolean {
+        return false
+    }
+
     override suspend fun initialize(args: Map<String, Any>): Boolean {
         // Make sure we have all the necessary data
         val application = args["application"] as? Application

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -110,6 +110,10 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver, IConfiguratio
         return result[ParameterKeys.Result] == ParameterValues.TRUE
     }
 
+    override suspend fun isOmniRefundsSupported(): Boolean {
+        return true
+    }
+
     override suspend fun isInitialized(): Boolean {
         return ChipDnaMobile.isInitialized()
     }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -225,7 +225,8 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
                     mobileReaderDriverRepository,
                     transactionRepository,
                     transaction,
-                    refundAmount
+                    refundAmount,
+                    omniApi
             ).start {
                 error(it)
             }?.let { completion(it) }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/MobileReaderDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/MobileReaderDriver.kt
@@ -35,6 +35,18 @@ internal interface MobileReaderDriver {
     suspend fun isReadyToTakePayment(): Boolean
 
     /**
+     * True when the Omni API can perform the refund
+     *
+     * Some `MobileReaderDriver`s, like NMI, support a deeper integration with Omni, such that Omni can facilitate the
+     * void/refund. This allows the SDK to relieve itself of the responsibility of having to perform the refund directly
+     * with the vendor (NMI), via the vendored SDK (ChipDNA).
+     *
+     * Other `MobileReaderDriver`s, like AWC, do not support this integration. For that reason, the SDK must perform
+     * the void/refund directly with AWC via the AWC sdk.
+     */
+    suspend fun isOmniRefundsSupported(): Boolean
+
+    /**
      * Attempts to initialize the [MobileReaderDriver]
      *
      * @throws InitializeMobileReaderDriverException

--- a/cardpresent/src/main/java/com/fattmerchant/omni/networking/OmniApi.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/networking/OmniApi.kt
@@ -14,6 +14,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.content.TextContent
 import io.ktor.http.isSuccess
+import org.json.JSONObject
 
 class OmniApi {
 
@@ -89,6 +90,22 @@ class OmniApi {
      */
     internal suspend fun createTransaction(transaction: Transaction, error: (Error) -> Unit): Transaction? =
         post("transaction", JsonParser.toJson(transaction), error)
+
+    /**
+     * Posts a void-or-refund to Omni
+     *
+     * @param transactionId the id of the transaction to void or refund
+     * @param total the amount in dollars to void or refund
+     * @return the voided or refunded transaction
+     */
+    internal suspend fun postVoidOrRefund(transactionId: String, total: String? = null, error: (Error) -> Unit): Transaction? {
+        val body = mutableMapOf<String, Any>()
+        total?.let {
+            body["total"] = it
+        }
+        return post("transaction/${transactionId}/void-or-refund", JSONObject(body).toString(), error)
+    }
+
 
     /**
      * Gets a list of transactions from Omni

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/RefundMobileReaderTransaction.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/RefundMobileReaderTransaction.kt
@@ -1,10 +1,12 @@
 package com.fattmerchant.omni.usecase
 
 import com.fattmerchant.omni.data.Amount
+import com.fattmerchant.omni.data.TransactionResult
 import com.fattmerchant.omni.data.models.OmniException
 import com.fattmerchant.omni.data.models.Transaction
 import com.fattmerchant.omni.data.repository.MobileReaderDriverRepository
 import com.fattmerchant.omni.data.repository.TransactionRepository
+import com.fattmerchant.omni.networking.OmniApi
 import kotlinx.coroutines.coroutineScope
 
 /**
@@ -15,44 +17,49 @@ import kotlinx.coroutines.coroutineScope
  * @property transaction
  */
 internal class RefundMobileReaderTransaction(
-    private val mobileReaderDriverRepository: MobileReaderDriverRepository,
-    private val transactionRepository: TransactionRepository,
-    internal val transaction: Transaction,
-    internal val refundAmount: Amount?
+        private val mobileReaderDriverRepository: MobileReaderDriverRepository,
+        private val transactionRepository: TransactionRepository,
+        internal val transaction: Transaction,
+        private val refundAmount: Amount?,
+        private val omniApi: OmniApi
 ) {
 
     class RefundException(message: String? = null) : OmniException("Could not refund transaction", message)
 
     suspend fun start(onError: (OmniException) -> Unit): Transaction? = coroutineScope {
         try {
-
             // Validate the refund
             validateRefund(transaction, refundAmount)?.let { throw it }
 
-            // Do the 3rd-party refund
-            val result = mobileReaderDriverRepository
-                .getDriverFor(transaction)
-                ?.refundTransaction(transaction, refundAmount)
+            // Get the driver
+            mobileReaderDriverRepository.getDriverFor(transaction).let { driver ->
+                // Check if Omni refund is supported by driver
+                if(driver?.isOmniRefundsSupported()!!) {
+                    transaction.id?.let { transactionId ->
+                        val response = omniApi.postVoidOrRefund(transactionId, refundAmount?.dollarsString()) {
+                            throw RefundException()
+                        }
 
-            if (result == null || result.success == false) {
-                throw RefundException()
-            }
+                        if (response == null || response.success == false) {
+                            throw RefundException()
+                        }
 
-            val refunded = Transaction().apply {
-                paymentMethodId = transaction.paymentMethodId
-                total = result.amount?.dollarsString()
-                success = result.success
-                lastFour = transaction.lastFour
-                type = "refund"
-                source = transaction.source
-                referenceId = transaction.id
-                method = transaction.method
-                customerId = transaction.customerId
-                invoiceId = transaction.invoiceId
-            }
+                        return@coroutineScope response
+                    }
+                } else {
+                    // Do the 3rd-party refund
+                    val result = mobileReaderDriverRepository
+                            .getDriverFor(transaction)
+                            ?.refundTransaction(transaction, refundAmount)
 
-            transactionRepository.create(refunded) {
-                throw RefundException(it.message)
+                    if (result == null || result.success == false) {
+                        throw RefundException()
+                    }
+
+                    postRefundedTransaction(result) {
+                        throw RefundException(it.message)
+                    }
+                }
             }
 
         } catch (e: RefundException) {
@@ -62,6 +69,13 @@ internal class RefundMobileReaderTransaction(
             onError(RefundException(e.message))
             return@coroutineScope null
         }
+    }
+
+    private suspend fun postRefundedTransaction(result: TransactionResult, error: (OmniException) -> Unit): Transaction? {
+        val refundedTransaction = Transaction()
+        refundedTransaction.total = result.amount?.dollarsString()
+        refundedTransaction.paymentMethodId = transaction.paymentMethodId
+        return transactionRepository.create(refundedTransaction, error)
     }
 
     companion object {


### PR DESCRIPTION
## What is this
This adds support in the SDK for the ability to refund through the Omni API when the driver allows for it. For instance when we post a refund from NMI.

## What did I do
Added a method to `OmniApi` called `postVoidOrRefund` which handles the post for refund or void through the api.
Added a bool called `isOmniRefundsSupported` to `MobileReaderDriver` (NMI is **true** and AWC is **false** by default).
In the `RefundMobileReaderTransaction` use case I added a check to see if we are able to do an Omni refund. If so we post a request to the api. If not we call to the third party refund method.
