### PR TITLE
[MOB-103] Add AWC transaction updates

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/anywherecommerce/AwcUtils.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/anywherecommerce/AwcUtils.kt
@@ -26,10 +26,10 @@ internal fun TransactionUpdate.Companion.from(anpMeaningfulMessage: MeaningfulMe
 
     return anpMeaningfulMessage.toString().let { message ->
         when (message) {
-            "SWIPE OR INSERT OR TAP" -> PromptInsertSwipeTap
+            "SWIPE OR INSERT OR TAP", "Insert, Swipe, or Tap Card"-> PromptInsertSwipeTap
             "SWIPE OR INSERT" -> PromptInsertSwipeCard
-            "Processing" -> Authorizing
-            "Remove Card" -> PromptRemoveCard
+            "PROCESSING" -> Authorizing
+            "REMOVE_CARD" -> PromptRemoveCard
             "INSERT_CARD" -> PromptInsertCard
             else -> null
         }


### PR DESCRIPTION
## What is this
AWC needs to handle transaction updates better

## What did I do
Delay the transaction update "Please Insert Swipe Tap" after a "Please Insert" transaction update. This makes it so the the user has time to see the "Please Insert" update that provides the corrective action before it gets replaced with the new one.

![image](https://user-images.githubusercontent.com/5385681/90926896-04170700-e3c2-11ea-8b4d-a02fb8934bac.png)
