### PR TITLE
[MOB-114] Connect reader not timing out and throwing error

### DIFF
--- a/cardpresent/build.gradle
+++ b/cardpresent/build.gradle
@@ -6,13 +6,13 @@ apply plugin: 'com.github.dcendents.android-maven'
 group='com.github.fattmerchantorg'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
-        versionCode 7
-        versionName "1.2.0"
+        targetSdkVersion 29
+        versionCode 8
+        versionName "1.2.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -17,6 +17,7 @@ import java.util.*
 import java.util.logging.Logger
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
 
@@ -162,7 +163,7 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
                 }
 
                 val error = params[ParameterKeys.ErrorDescription]
-                throw ConnectReaderException(error)
+                cont.resumeWithException(ConnectReaderException(error))
             }
 
             ChipDnaMobile.getInstance().addConnectAndConfigureFinishedListener(connectAndConfigureListener)


### PR DESCRIPTION
## What is this
When trying to connect to an NMI mobile reader that is paired but powered off, the SDK was not invoking the success or the fail callbacks. This left the consuming application in an infinite waiting state.

## What did I do
There was a bug in the way that we were throwing the exception. We were calling throw within a sub coroutine, and the parent coroutine was not rethrowing. I called the proper method, `cancellableContinuation.resumeWithException(Exception)` as per this doc https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-cancellable-continuation/#


![image](https://user-images.githubusercontent.com/5385681/91720656-7d062380-eb65-11ea-8155-f1629b22d43f.png)
