### PR TITLE
[MOB-122] pass in "channel": "android" on transaction POST/PUT

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/Invoice.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/Invoice.kt
@@ -30,5 +30,4 @@ open class Invoice: Model {
     open var url: String? = null
     open var userId: String? = null
     open var viewedAt: String? = null
-    open var channel: String = "android"
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/Invoice.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/Invoice.kt
@@ -30,4 +30,5 @@ open class Invoice: Model {
     open var url: String? = null
     open var userId: String? = null
     open var viewedAt: String? = null
+    open var channel: String = "android"
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/Transaction.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/Transaction.kt
@@ -44,4 +44,5 @@ open class Transaction : Model {
     open var type: String? = null
     open var updatedAt: String? = null
     open var userId: String? = null
+    open var channel: String = "android"
 }


### PR DESCRIPTION
[MOB-122 pass in "channel": "android" on invoice and transaction POST/PUT](https://fattmerchant.atlassian.net/browse/MOB-122)

## What is this?
Transaction did not have field `channel`

## What did I do?
• Added channel field to Transaction model

## Screenshots/GIFs
<img width="1417" alt="Screen Shot 2020-09-15 at 3 09 11 PM" src="https://user-images.githubusercontent.com/10945265/93254310-29e7bf80-f766-11ea-9366-07761f33e82e.png">
