### PR TITLE
[MOB-340] Use /payment-method instead of /webpayments to tokenize

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -62,6 +62,12 @@
                 android:text="Initialize" />
 
             <Button
+                android:id="@+id/buttonPerformSaleWithReader"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Perform sale with reader" />
+
+            <Button
                 android:id="@+id/buttonPerformSale"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -78,23 +78,23 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
             merchant.emvPassword()?.let { nmiDetails.securityKey = it }
             mutatedArgs["nmi"] = nmiDetails
 
-            val mobileReaderDetails = omniApi.getMobileReaderSettings {
-                error(OmniException("Could not get reader settings", it.message))
-            } ?: return@launch
+            omniApi.getMobileReaderSettings {
+                // error(OmniException("Could not get reader settings", it.message))
+            }?.let { mobileReaderDetails ->
+                mobileReaderDetails.nmi?.let {
+                    mutatedArgs["nmi"] = it
+                }
 
-            mobileReaderDetails.nmi?.let {
-                mutatedArgs["nmi"] = it
+                mobileReaderDetails.anywhereCommerce?.let {
+                    mutatedArgs["awc"] = it
+                }
+
+                InitializeDrivers(
+                        mobileReaderDriverRepository,
+                        mutatedArgs,
+                        coroutineContext
+                ).start(error)
             }
-
-            mobileReaderDetails.anywhereCommerce?.let {
-                mutatedArgs["awc"] = it
-            }
-
-            InitializeDrivers(
-                    mobileReaderDriverRepository,
-                    mutatedArgs,
-                    coroutineContext
-            ).start(error)
 
             initialized = true
 

--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -3,10 +3,7 @@ package com.fattmerchant.omni
 import com.fattmerchant.omni.data.Amount
 import com.fattmerchant.omni.data.MobileReader
 import com.fattmerchant.omni.data.TransactionRequest
-import com.fattmerchant.omni.data.models.Invoice
-import com.fattmerchant.omni.data.models.MobileReaderDetails
-import com.fattmerchant.omni.data.models.OmniException
-import com.fattmerchant.omni.data.models.Transaction
+import com.fattmerchant.omni.data.models.*
 import com.fattmerchant.omni.data.repository.*
 import com.fattmerchant.omni.networking.OmniApi
 import com.fattmerchant.omni.usecase.*
@@ -188,6 +185,37 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
             )
 
             onDisconnected(job.start(onFail))
+        }
+    }
+
+    /**
+     * Charges a transaction
+     *
+     * @param transactionRequest a [TransactionRequest] object that includes all the information needed to
+     * run this transaction including [TransactionRequest.amount] and [TransactionRequest.tokenize]
+     * @param completion a block to run once the transaction is finished. Receives the completed
+     * [Transaction]
+     * @param error a block to run if an error is thrown. Receives an [OmniException]
+     */
+    fun pay(transactionRequest: TransactionRequest, completion: (Transaction) -> Unit, error: (OmniException) -> Unit) {
+        coroutineScope.launch {
+            val takePaymentJob = TakePayment(
+                    customerRepository = customerRepository,
+                    paymentMethodRepository = paymentMethodRepository,
+                    request = transactionRequest,
+                    omniApi = omniApi,
+                    coroutineContext = coroutineContext)
+
+            currentJob = takePaymentJob
+
+            val result = takePaymentJob.start {
+                error(it)
+                return@start
+            }
+
+            result?.let {
+                completion(it)
+            }
         }
     }
 

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
@@ -1,7 +1,9 @@
 package com.fattmerchant.omni.data
 
+import com.fattmerchant.omni.data.models.BankAccount
 import com.fattmerchant.omni.data.models.CatalogItem
 import com.fattmerchant.omni.data.models.CreditCard
+import com.fattmerchant.omni.data.models.Transaction
 
 /**
  * A request for a transaction
@@ -20,6 +22,9 @@ data class TransactionRequest(
 
     /** The [CreditCard] to charge */
     var card: CreditCard? = null,
+
+    /** The [BankAccount] to charge */
+    var bankAccount: BankAccount? = null,
 
     /** A list of [CatalogItem]s to associate with the [Transaction]
      *
@@ -70,6 +75,16 @@ data class TransactionRequest(
     constructor(amount: Amount, creditCard: CreditCard) : this(amount, true, null, creditCard)
 
     /**
+     * Initializes a Transaction with the given [Amount] and [BankAccount]
+     *
+     * Note that this will request tokenization
+     *
+     * @param amount The [Amount] to be collected during the transaction
+     * @param bankAccount The [BankAccount] used for the transaction
+     * */
+    constructor(amount: Amount, bankAccount: BankAccount) : this(amount, true, bankAccount = bankAccount)
+
+    /**
      * Initializes a Transaction with the given [Amount] and invoiceId
      *
      * Note that this will request tokenization
@@ -88,5 +103,5 @@ data class TransactionRequest(
      * @param lineItems The [CatalogItem]s to be added to the transaction
      * */
     constructor(amount: Amount, lineItems: List<CatalogItem>?)
-            : this(amount, true, null, null, lineItems)
+            : this(amount, true, lineItems = lineItems)
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
@@ -1,6 +1,7 @@
 package com.fattmerchant.omni.data
 
 import com.fattmerchant.omni.data.models.CatalogItem
+import com.fattmerchant.omni.data.models.CreditCard
 
 /**
  * A request for a transaction
@@ -16,6 +17,9 @@ data class TransactionRequest(
 
     /** The id of the invoice we want to apply the transaction to */
     var invoiceId: String? = null,
+
+    /** The [CreditCard] to charge */
+    var card: CreditCard? = null,
 
     /** A list of [CatalogItem]s to associate with the [Transaction]
      *
@@ -74,5 +78,5 @@ data class TransactionRequest(
      * @param lineItems The [CatalogItem]s to be added to the transaction
      * */
     constructor(amount: Amount, lineItems: List<CatalogItem>?)
-            : this(amount, true, null, lineItems)
+            : this(amount, true, null, null ,lineItems)
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
@@ -78,5 +78,5 @@ data class TransactionRequest(
      * @param lineItems The [CatalogItem]s to be added to the transaction
      * */
     constructor(amount: Amount, lineItems: List<CatalogItem>?)
-            : this(amount, true, null, null ,lineItems)
+            : this(amount, true, null, null, lineItems)
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
@@ -60,6 +60,16 @@ data class TransactionRequest(
     constructor(amount: Amount) : this(amount, true)
 
     /**
+     * Initializes a Transaction with the given [Amount] and [CreditCard]
+     *
+     * Note that this will request tokenization
+     *
+     * @param amount The [Amount] to be collected during the transaction
+     * @param creditCard The [CreditCard] used for the transaction
+     * */
+    constructor(amount: Amount, creditCard: CreditCard) : this(amount, true, null, creditCard)
+
+    /**
      * Initializes a Transaction with the given [Amount] and invoiceId
      *
      * Note that this will request tokenization

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/BankAccount.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/BankAccount.kt
@@ -1,0 +1,113 @@
+package com.fattmerchant.omni.data.models
+
+import com.squareup.moshi.Json
+
+/** A bank account */
+class BankAccount(
+
+        @Json(name = "person_name")
+        var personName: String,
+
+        @Json(name = "bank_type")
+        var bankType: String = "checkings",
+
+        @Json(name = "bank_holder_type")
+        var bankHolderType: String = "business",
+
+        @Json(name = "bank_account")
+        var bankAccount: String,
+
+        @Json(name = "bank_routing")
+        var bankRouting: String,
+
+        @Json(name = "address_zip")
+        var addressZip: String,
+
+        @Json(name = "bank_name")
+        var bankName: String? = null,
+
+        @Json(name = "address_1")
+        var address1: String? = null,
+
+        @Json(name = "address_2")
+        var address2: String? = null,
+
+        @Json(name = "address_city")
+        var addressCity: String? = null,
+
+        @Json(name = "address_state")
+        var addressState: String? = null,
+
+        @Json(name = "customer_id")
+        var customerId: String? = null,
+
+        var note: String? = null,
+        var phone: String? = null,
+        var email: String? = null
+) {
+
+    private var method: String = "bank"
+
+    @Deprecated("Please use the new constructor that does not use the `method` parameter",
+            ReplaceWith("BankAccount(personName, bankType, bankHolderType, bankAccount, bankRouting, addressZip, bankName, address1, address2, addressCity, addressState, customerId, note, phone, email)"))
+    constructor(personName: String,
+                bankType: String,
+                bankHolderType: String,
+                bankAccount: String,
+                bankRouting: String,
+                addressZip: String,
+                bankName: String?,
+                address1: String?,
+                address2: String?,
+                addressCity: String?,
+                addressState: String?,
+                customerId: String?,
+                note: String?,
+                phone: String?,
+                email: String?,
+                method: String?
+    ) : this(personName, bankType, bankHolderType, bankAccount, bankRouting, addressZip, bankName, address1, address2, addressCity, addressState, customerId, note, phone, email)
+
+    fun firstName(): String {
+        val splitName = personName.split(" ")
+        return splitName.first()
+    }
+
+    fun lastName(): String {
+        val splitName = personName.split(" ") as MutableList<String>
+        splitName.removeAt(0)
+        return splitName.joinToString(" ")
+    }
+
+    companion object {
+        /**
+         * Creates a test bank account
+         *
+         * @return a test bank account
+         */
+        fun testBankAccount() = BankAccount(personName = "Jim Parsnip", bankType = "savings", bankAccount = "9876543210", bankRouting = "021000021", addressZip = "32822").apply {
+            address1 = "123 Orange Ave"
+            address2 = "Unit 309"
+            addressCity = "Orlando"
+            addressState = "FL"
+            phone = "3210000000"
+            email = "fatt@merchant.com"
+            note = "This is a test credit card"
+        }
+
+        /**
+         * Creates a test bank account that fails processing
+         *
+         * @return a test bank account
+         */
+        fun failingTestBankAccount() = BankAccount(personName = "Jim Parsnip", bankAccount = "9876543210", bankRouting = "021000021", addressZip = "32822").apply {
+            address1 = "123 Orange Ave"
+            address2 = "Unit 309"
+            addressCity = "Orlando"
+            addressState = "FL"
+            phone = "3210000000"
+            email = "fatt@merchant.com"
+            note = "This is a test credit card"
+        }
+    }
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/ChargeRequest.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/ChargeRequest.kt
@@ -1,0 +1,11 @@
+package com.fattmerchant.omni.data.models
+
+import com.squareup.moshi.Json
+
+class ChargeRequest(
+        @Json(name = "payment_method_id")
+        var paymentMethodId: String,
+        var total: String,
+        var preAuth: Boolean,
+        var meta: Any? = null
+)

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/CreditCard.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/CreditCard.kt
@@ -1,0 +1,104 @@
+package com.fattmerchant.omni.data.models
+
+import com.squareup.moshi.Json
+
+/** A credit card */
+class CreditCard(
+
+        @Json(name = "person_name")
+        var personName: String,
+
+        @Json(name = "card_number")
+        var cardNumber: String,
+
+        @Json(name = "card_exp")
+        var cardExp: String,
+
+        @Json(name = "address_zip")
+        var addressZip: String,
+
+        @Json(name = "address_1")
+        var address1: String? = null,
+
+        @Json(name = "address_2")
+        var address2: String? = null,
+
+        @Json(name = "address_city")
+        var addressCity: String? = null,
+
+        @Json(name = "address_state")
+        var addressState: String? = null,
+
+        @Json(name = "customer_id")
+        var customerId: String? = null,
+
+        var note: String? = null,
+        var phone: String? = null,
+        var email: String? = null
+) {
+
+    private var method: String = "card"
+
+    @Deprecated("Please use the new constructor that does not use the `method` parameter",
+            ReplaceWith("CreditCard(personName, cardNumber, cardExp, addressZip, address1, address2, addressCity, addressState, customerId, note, phone, email)"))
+    constructor(personName: String,
+                cardNumber: String,
+                cardExp: String,
+                addressZip: String,
+                address1: String?,
+                address2: String?,
+                addressCity: String?,
+                addressState: String?,
+                customerId: String?,
+                note: String?,
+                phone: String?,
+                email: String?,
+                method: String? = "card")
+            : this(personName, cardNumber, cardExp, addressZip, address1, address2, addressCity, addressState, customerId, note, phone, email) {
+        this.method = "card"
+    }
+
+    fun firstName(): String {
+        val splitName = personName.split(" ")
+        return splitName.first()
+    }
+
+    fun lastName(): String {
+        val splitName = personName.split(" ") as MutableList<String>
+        splitName.removeAt(0)
+        return splitName.joinToString(" ")
+    }
+
+
+    companion object {
+        /**
+         * Creates a test credit card
+         *
+         * @return a test credit card
+         */
+        fun testCreditCard() = CreditCard(personName = "Joan Parsnip", cardNumber = "4111111111111111", cardExp = "1230", addressZip = "32822").apply {
+            address1 = "123 Orange Ave"
+            address2 = "Unit 309"
+            addressCity = "Orlando"
+            addressState = "FL"
+            phone = "3210000000"
+            email = "fatt@merchant.com"
+            note = "This is a test credit card"
+        }
+
+        /**
+         * Creates a test credit card that fails processing
+         *
+         * @return a test credit card
+         */
+        fun failingTestCreditCard() = CreditCard(personName = "Joan Parsnip", cardNumber = "4111111111111111", cardExp = "", addressZip = "32822").apply {
+            address1 = "123 Orange Ave"
+            address2 = "Unit 309"
+            addressCity = "Orlando"
+            addressState = "FL"
+            phone = "3210000000"
+            email = "fatt@merchant.com"
+            note = "This is a test credit card"
+        }
+    }
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/PaymentMethod.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/PaymentMethod.kt
@@ -55,4 +55,24 @@ open class PaymentMethod : Model {
      * @note If this field is not `null`, then `tokenize` must be `false`
      */
     internal var paymentToken: String? = null
+
+    /**
+     * The card number
+     */
+    internal var cardNumber: String? = null
+
+    /**
+     * The card CVV
+     */
+    internal var cardCvv: String? = null
+
+    /**
+     * The bank account number
+     */
+    internal var bankAccount: String? = null
+
+    /**
+     * The bank routing number
+     */
+    internal var bankRouting: String? = null
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/PaymentMethod.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/PaymentMethod.kt
@@ -26,7 +26,7 @@ open class PaymentMethod : Model {
     open var isDefault: Int? = null
     open var isUsableInVt: Boolean? = null
     open var merchantId: String? = null
-    open var meta: String? = null
+    open var meta: Any? = null
     open var method: String? = null
     open var nickname: String? = null
     open var personName: String? = null

--- a/cardpresent/src/main/java/com/fattmerchant/omni/networking/OmniApi.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/networking/OmniApi.kt
@@ -1,5 +1,6 @@
 package com.fattmerchant.omni.networking
 
+import com.fattmerchant.omni.data.TransactionResult
 import com.fattmerchant.omni.data.models.*
 import com.google.gson.FieldNamingPolicy
 import io.ktor.client.HttpClient
@@ -157,6 +158,9 @@ class OmniApi {
         return post(url, JsonParser.toJson(paymentMethod), error)
     }
 
+    internal suspend fun charge(chargeRequest: ChargeRequest, error: (Error) -> Unit): Transaction? {
+        return post("charge", JsonParser.toJson(chargeRequest), error)
+    }
 
     private suspend inline fun <reified T> post(urlString: String, body: String, error: (Error) -> Unit): T? =
         this.request<T>(

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakePayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakePayment.kt
@@ -20,9 +20,10 @@ internal class TakePayment(val customerRepository: CustomerRepository,
 
     suspend fun start(failure: (OmniException) -> Unit): Transaction? = coroutineScope {
 
-        request.card?.let {
-            failure(OmniException("No payment method provided"))
-        }?: return@coroutineScope null
+        if(request.card == null) {
+            failure(OmniException("No payment method provided."))
+            return@coroutineScope null
+        }
 
         val tokenizeJob = TokenizePaymentMethod(
                 customerRepository = customerRepository,
@@ -40,7 +41,6 @@ internal class TakePayment(val customerRepository: CustomerRepository,
                 failure(OmniException("Charging the payment method was unsuccessful."))
             }
         }?: return@coroutineScope null
-
     }
 
     private fun createChargeRequest(amount: Amount, paymentMethodId: String): ChargeRequest {

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakePayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakePayment.kt
@@ -24,7 +24,11 @@ internal class TakePayment(val customerRepository: CustomerRepository,
             failure(OmniException("No payment method provided"))
         }?: return@coroutineScope null
 
-        val tokenizeJob = TokenizePaymentMethod(customerRepository, paymentMethodRepository, request.card, coroutineContext = coroutineContext)
+        val tokenizeJob = TokenizePaymentMethod(
+                customerRepository = customerRepository,
+                paymentMethodRepository = paymentMethodRepository,
+                creditCard = request.card,
+                coroutineContext = coroutineContext)
 
         val tokenizedPaymentMethod = tokenizeJob.start {
             failure(it)

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakePayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakePayment.kt
@@ -1,0 +1,46 @@
+package com.fattmerchant.omni.usecase
+
+import com.fattmerchant.omni.data.Amount
+import com.fattmerchant.omni.data.TransactionRequest
+import com.fattmerchant.omni.data.models.ChargeRequest
+import com.fattmerchant.omni.data.models.OmniException
+import com.fattmerchant.omni.data.models.Transaction
+import com.fattmerchant.omni.data.repository.CustomerRepository
+import com.fattmerchant.omni.data.repository.PaymentMethodRepository
+import com.fattmerchant.omni.networking.OmniApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlin.coroutines.CoroutineContext
+
+internal class TakePayment(val customerRepository: CustomerRepository,
+                           val paymentMethodRepository: PaymentMethodRepository,
+                           val request: TransactionRequest,
+                           val omniApi: OmniApi,
+                           override val coroutineContext: CoroutineContext) : CoroutineScope {
+
+    suspend fun start(failure: (OmniException) -> Unit): Transaction? = coroutineScope {
+
+        request.card?.let {
+            failure(OmniException("No payment method provided"))
+        }?: return@coroutineScope null
+
+        val tokenizeJob = TokenizePaymentMethod(customerRepository, paymentMethodRepository, request.card, coroutineContext = coroutineContext)
+
+        val tokenizedPaymentMethod = tokenizeJob.start {
+            failure(it)
+        }?: return@coroutineScope null
+
+        tokenizedPaymentMethod.id?.let {
+            val chargeRequest = createChargeRequest(request.amount, it)
+            omniApi.charge(chargeRequest) { error ->
+                failure(OmniException("Charging the payment method was unsuccessful."))
+            }
+        }?: return@coroutineScope null
+
+    }
+
+    private fun createChargeRequest(amount: Amount, paymentMethodId: String): ChargeRequest {
+        val chargeRequestMeta = mapOf("subtotal" to amount.dollarsString())
+        return ChargeRequest(paymentMethodId, amount.dollarsString(), false, chargeRequestMeta)
+    }
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TokenizePaymentMethod.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TokenizePaymentMethod.kt
@@ -20,13 +20,13 @@ internal class TokenizePaymentMethod(
         var lastName: String? = null
         var customer: Customer? = null
 
-        creditCard?.let {
-            firstName = it.firstName()
-            lastName = it.lastName()
+        creditCard?.personName?.let {
+            firstName = creditCard.firstName()
+            lastName = creditCard.lastName()
         }.run {
-            bankAccount?.let {
-                firstName = it.firstName()
-                lastName = it.lastName()
+            bankAccount?.personName?.let {
+                firstName = bankAccount.firstName()
+                lastName = bankAccount.lastName()
             }?.run {
                 failure(OmniException("No name supplied."))
                 return@coroutineScope null
@@ -55,6 +55,7 @@ internal class TokenizePaymentMethod(
                 method = "card"
                 this.cardLastFour = cardLastFour
                 personName = card.personName
+                cardNumber = card.cardNumber
                 tokenize = true
             }
         }.run {

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TokenizePaymentMethod.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TokenizePaymentMethod.kt
@@ -36,7 +36,7 @@ internal class TokenizePaymentMethod(
             customer = customerRepository.getById(it) { exception ->
                 failure(exception)
             } ?: return@coroutineScope null
-        }?.run {
+        }.run {
             customer = customerRepository.create(Customer().apply {
                 this.firstname =  firstName?: "SWIPE"
                 this.lastname = lastName?: "CUSTOMER"
@@ -49,18 +49,16 @@ internal class TokenizePaymentMethod(
 
         creditCard?.let { card ->
             paymentMethod = PaymentMethod().apply {
-                merchantId = customer?.merchantId
                 customerId = customer?.id
                 method = "card"
-                this.cardLastFour = cardLastFour
                 personName = card.personName
                 cardNumber = card.cardNumber
-                tokenize = true
+                addressZip = card.addressZip
+                cardExp = card.cardExp
             }
         }.run {
             bankAccount?.let {  bank ->
                 paymentMethod = PaymentMethod().apply {
-                    merchantId = customer?.merchantId
                     customerId = customer?.id
                     method = "bank"
                     bankAccount = bank.bankAccount
@@ -68,7 +66,6 @@ internal class TokenizePaymentMethod(
                     bankName = bank.bankName
                     bankType = bank.bankType
                     personName = bank.personName
-                    tokenize = true
                 }
             }?.run {
                 failure(OmniException("No credit card or bank information was supplied."))

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TokenizePaymentMethod.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TokenizePaymentMethod.kt
@@ -63,7 +63,10 @@ internal class TokenizePaymentMethod(
                     merchantId = customer?.merchantId
                     customerId = customer?.id
                     method = "bank"
-                    this.cardLastFour = cardLastFour
+                    bankAccount = bank.bankAccount
+                    bankRouting = bank.bankRouting
+                    bankName = bank.bankName
+                    bankType = bank.bankType
                     personName = bank.personName
                     tokenize = true
                 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TokenizePaymentMethod.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TokenizePaymentMethod.kt
@@ -1,0 +1,80 @@
+package com.fattmerchant.omni.usecase
+
+import com.fattmerchant.omni.data.models.*
+import com.fattmerchant.omni.data.repository.CustomerRepository
+import com.fattmerchant.omni.data.repository.PaymentMethodRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlin.coroutines.CoroutineContext
+
+/// Tokenizes a payment method
+internal class TokenizePaymentMethod(
+        val customerRepository: CustomerRepository,
+        val paymentMethodRepository: PaymentMethodRepository,
+        val creditCard: CreditCard? = null,
+        val bankAccount: BankAccount? = null,
+        override val coroutineContext: CoroutineContext) : CoroutineScope {
+
+    suspend fun start(failure: (OmniException) -> Unit): PaymentMethod? = coroutineScope {
+        var firstName: String? = null
+        var lastName: String? = null
+        var customer: Customer? = null
+
+        creditCard?.let {
+            firstName = it.firstName()
+            lastName = it.lastName()
+        }.run {
+            bankAccount?.let {
+                firstName = it.firstName()
+                lastName = it.lastName()
+            }?.run {
+                failure(OmniException("No name supplied."))
+                return@coroutineScope null
+            }
+        }
+
+        creditCard?.customerId?.let {
+            customer = customerRepository.getById(it) { exception ->
+                failure(exception)
+            } ?: return@coroutineScope null
+        }?.run {
+            customer = customerRepository.create(Customer().apply {
+                this.firstname =  firstName?: "NO"
+                this.lastname = lastName?: "NAME"
+            }) { exception ->
+                failure(exception)
+            } ?: return@coroutineScope null
+        }
+
+        var paymentMethod = PaymentMethod()
+
+        creditCard?.let { card ->
+            paymentMethod = PaymentMethod().apply {
+                merchantId = customer?.merchantId
+                customerId = customer?.id
+                method = "card"
+                this.cardLastFour = cardLastFour
+                personName = card.personName
+                tokenize = true
+            }
+        }.run {
+            bankAccount?.let {  bank ->
+                paymentMethod = PaymentMethod().apply {
+                    merchantId = customer?.merchantId
+                    customerId = customer?.id
+                    method = "bank"
+                    this.cardLastFour = cardLastFour
+                    personName = bank.personName
+                    tokenize = true
+                }
+            }?.run {
+                failure(OmniException("No credit card or bank information was supplied."))
+                return@coroutineScope null
+            }
+        }
+
+        paymentMethodRepository.create(paymentMethod) { exception ->
+            failure(exception)
+        }
+    }
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TokenizePaymentMethod.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TokenizePaymentMethod.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlin.coroutines.CoroutineContext
 
-/// Tokenizes a payment method
 internal class TokenizePaymentMethod(
         val customerRepository: CustomerRepository,
         val paymentMethodRepository: PaymentMethodRepository,
@@ -39,8 +38,8 @@ internal class TokenizePaymentMethod(
             } ?: return@coroutineScope null
         }?.run {
             customer = customerRepository.create(Customer().apply {
-                this.firstname =  firstName?: "NO"
-                this.lastname = lastName?: "NAME"
+                this.firstname =  firstName?: "SWIPE"
+                this.lastname = lastName?: "CUSTOMER"
             }) { exception ->
                 failure(exception)
             } ?: return@coroutineScope null


### PR DESCRIPTION
[MOB-340 Android SDK | The Android SDK needs to use /payment-method instead of /webpayments to tokenize](https://fattmerchant.atlassian.net/browse/MOB-340)

## What is this?
The Android SDK currently uses POST /webpayments/{hostedpaymentstoken}/tokenize in order to tokenize a payment method. This flow is not supported and we need to start using POST /payment-method

## What did I do?
- Added use cases for TakePayment and TokenizePaymentMethod
- Added `pay` method to Omni.kt to take a `TransactionRequest` and charge it
- Added test case to sample app for taking a payment without reader 

## Screenshots / GIFs