### PR TITLE
Release/1.2.2

### DIFF
--- a/cardpresent/src/androidTest/java/com/fattmerchant/cpresent/InitializeDriversTest.kt
+++ b/cardpresent/src/androidTest/java/com/fattmerchant/cpresent/InitializeDriversTest.kt
@@ -1,0 +1,46 @@
+package com.fattmerchant.cpresent
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.runner.AndroidJUnit4
+import com.fattmerchant.android.MobileReaderDriverRepository
+import com.fattmerchant.omni.data.MobileReaderDriver
+import com.fattmerchant.omni.data.models.Merchant
+import com.fattmerchant.omni.data.models.OmniException
+import com.fattmerchant.omni.usecase.InitializeDrivers
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class InitializeDriversTest {
+
+    @Test
+    fun initializationFailsIfNoCredsProvided() {
+        // Setup
+        var error: OmniException? = null
+        val expectedError = MobileReaderDriver.InitializeMobileReaderDriverException("emv_password not found")
+        val merchant = Merchant().apply {
+            // Note that the empty map will cause the ChipDnaDriver to never get the creds it needs to initialize itself
+            options = mapOf()
+        }
+        val args = mapOf(
+                "appContext" to ApplicationProvider.getApplicationContext(),
+                "appId" to "123",
+                "merchant" to merchant
+        )
+        val job = InitializeDrivers(MobileReaderDriverRepository(), args, Dispatchers.Default)
+
+        // Start the job and capture the error
+        runBlocking {
+            job.start {
+                error = it
+            }
+        }
+
+        // Assert that the error returned is the expected one
+        assertEquals(error?.message, expectedError.message)
+        assertEquals(error?.detail, expectedError.detail)
+    }
+}

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -124,6 +124,8 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
         val parameters = Parameters().apply {
             add(ParameterKeys.SearchConnectionTypeBluetooth, ParameterValues.TRUE)
         }
+        if (!ChipDnaMobile.isInitialized()) { return emptyList() }
+
         ChipDnaMobile.getInstance().clearAllAvailablePinPadsListeners()
 
         val pinPads = suspendCancellableCoroutine<List<SelectablePinPad>> { cont ->
@@ -144,6 +146,7 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
         }
     }
 
+    @UseExperimental(InternalCoroutinesApi::class)
     override suspend fun connectReader(reader: MobileReader): Boolean {
 
         val requestParams = Parameters()
@@ -163,7 +166,7 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
                 }
 
                 val error = params[ParameterKeys.ErrorDescription]
-                cont.resumeWithException(ConnectReaderException(error))
+                cont.tryResumeWithException(ConnectReaderException(error))
             }
 
             ChipDnaMobile.getInstance().addConnectAndConfigureFinishedListener(connectAndConfigureListener)

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -97,7 +97,7 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
             ?: throw InitializeMobileReaderDriverException("merchant not found")
 
         val apiKey = merchant.emvPassword()
-            ?: throw InitializeMobileReaderDriverException("emvTerminalSecret not found")
+            ?: throw InitializeMobileReaderDriverException("emv_password not found")
 
         val params = Parameters().apply {
             add(ParameterKeys.Password, "password")


### PR DESCRIPTION
# Release/1.2.2

### SPRINT-165 MOB-468 Android SDK | If there are no mobile reader settings, the sdk crashes

[Github PR #31](https://github.com/fattmerchantorg/fattmerchant-android-sdk/pull/31)
[Jira Ticket MOB-468](https://fattmerchant.atlassian.net/browse/MOB-468)

* Changed the `InitializeDrivers` functionality to wrap each driver's `initialize` call with a try...catch. What was happening here was that the whole [getDrivers().map().blah()](https://github.com/fattmerchantorg/fattmerchant-android-sdk/compare/release/1.2.2...feature/MOB-468-initialization-crash?expand=1#diff-0300444504bc7b8a102610564bd10fde6a663d375272f3fcefd56342c317dd15L20-L25) was being wrapped in the try...catch, and idk if it has something to do with those being suspend functions, but the throwing exceptions were not being caught by the surrounding try...catch. 
* Updated the error message of the ChipDnaDriver to accurately represent the _actual_ error. This is going to let users receive the `detail` that they should be receiving, which will let them and us debug much faster
* Wrote a test to ensure that the proper error gets thrown under this circumstance
