### PR TITLE
[SPRINT-171][MOB-564] Added flags for TMS and Firmware updates

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
@@ -127,7 +127,7 @@ internal fun Parameters.withTransactionRequest(request: TransactionRequest) = Pa
  * ChipDna hands us a ton of configuration updates during the mobile reader connection process
  * The ones we care about are:
  *  - Connecting
- *  - Permorming Tms Update
+ *  - Performing Tms Update
  *  - Updating Pinpad Firmware
  *  - Rebooting
  *  - Registering
@@ -135,12 +135,10 @@ internal fun Parameters.withTransactionRequest(request: TransactionRequest) = Pa
  * @param chipDnaConfigurationUpdate
  */
 fun MobileReaderConnectionStatus.Companion.from(chipDnaConfigurationUpdate: String): MobileReaderConnectionStatus? = when(chipDnaConfigurationUpdate) {
+    ParameterValues.Registering,
     ParameterValues.Connecting -> MobileReaderConnectionStatus.CONNECTING
-
-    ParameterValues.UpdatingPinPadFirmware,
-    ParameterValues.PerformingTmsUpdate,
-    ParameterValues.Registering -> MobileReaderConnectionStatus.UPDATING
-
+    ParameterValues.PerformingTmsUpdate -> MobileReaderConnectionStatus.UPDATING_CONFIGURATION
+    ParameterValues.UpdatingPinPadFirmware -> MobileReaderConnectionStatus.UPDATING_FIRMWARE
     ParameterValues.RebootingPinPad -> MobileReaderConnectionStatus.REBOOTING
 
     else -> null

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/models/MobileReaderConnectionStatus.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/models/MobileReaderConnectionStatus.kt
@@ -12,9 +12,14 @@ enum class MobileReaderConnectionStatus(val status: String) {
     DISCONNECTED("disconnected"),
 
     /** The reader is performing an update
-     * - Note: This might be a long-running operation
+     * - Note: This includes TMS and Config updates
      */
-    UPDATING("updating"),
+    UPDATING_CONFIGURATION("updatingConfiguration"),
+
+    /** The reader is performing an update on the firmware
+     * - Note: This is a long running operation
+     */
+    UPDATING_FIRMWARE("updatingFirmware"),
 
     /** The reader is performing a reboot */
     REBOOTING("rebooting");


### PR DESCRIPTION
## **[Ticket MOB-564](https://fattmerchant.atlassian.net/browse/MOB-564)**
> **Android SDK | NMI bbPOS | Getting latest settings**
## What did I do?
* Added flags for TMS and Firmware updates
* Combined `Registering` status with `Connecting`
---

<!-- YOU CAN DELETE THE SCREENSHOTS SECTION IF NOT APPLICABLE -->
## Screenshot(s):

---

## PR notes contain:
* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)
## PR Checklist:
* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
