### PR TITLE
[SPRINT-171][MOB-562] Provide UserNotificationListener to SDK

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity android:name=".MainActivity"
-            android:configChanges="orientation">
+            android:configChanges="orientation|keyboardHidden|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/fattmerchant/fmsampleclient/MainActivity.kt
+++ b/app/src/main/java/com/fattmerchant/fmsampleclient/MainActivity.kt
@@ -8,10 +8,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.fattmerchant.android.InitParams
 import com.fattmerchant.android.Omni
 import com.fattmerchant.omni.TransactionUpdateListener
-import com.fattmerchant.omni.data.Amount
-import com.fattmerchant.omni.data.MobileReader
-import com.fattmerchant.omni.data.TransactionRequest
-import com.fattmerchant.omni.data.TransactionUpdate
+import com.fattmerchant.omni.UserNotificationListener
+import com.fattmerchant.omni.data.*
 import com.fattmerchant.omni.data.models.CreditCard
 import com.fattmerchant.omni.data.models.OmniException
 import com.fattmerchant.omni.data.models.Transaction
@@ -54,6 +52,16 @@ class MainActivity : AppCompatActivity() {
             Omni.shared()?.transactionUpdateListener = object: TransactionUpdateListener {
                 override fun onTransactionUpdate(transactionUpdate: TransactionUpdate) {
                     updateStatus("${transactionUpdate.value} | ${transactionUpdate.userFriendlyMessage}")
+                }
+            }
+
+            Omni.shared()?.userNotificationListener = object: UserNotificationListener {
+                override fun onUserNotification(userNotification: UserNotification) {
+                    updateStatus("${userNotification.value} | ${userNotification.userFriendlyMessage}")
+                }
+
+                override fun onRawUserNotification(userNotification: String) {
+                    updateStatus(userNotification)
                 }
             }
 
@@ -195,7 +203,7 @@ class MainActivity : AppCompatActivity() {
                 dialog.dismiss()
                 // If you want to not use the apikey dialog, modify the initializeOmni call like below
                 // initializeOmni("insert api key here")
-                initializeOmni("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjaGFudCI6IjRjMTc2ZGFhLTg1OGUtNDIzYi1hOGQ1LTU4NTA5ZDA0MTExMiIsImdvZFVzZXIiOnRydWUsImJyYW5kIjoiZmF0dG1lcmNoYW50LXNhbmRib3giLCJzdWIiOiIxMjgwZGQ0ZC0xMjYxLTRhYjUtOGRmYi1jYWYxZjdkOGNlMzQiLCJpc3MiOiJodHRwOi8vYXBpZGV2MDEuZmF0dGxhYnMuY29tL2F1dGhlbnRpY2F0ZSIsImlhdCI6MTYwNzQ0ODkxMSwiZXhwIjoxNjA3NTM1MzExLCJuYmYiOjE2MDc0NDg5MTEsImp0aSI6ImVnZFdsSmFUYTBWRDFwUTIifQ.jnrptnoG6Z5PQ6xf_O-2FEvR91k3kPFvvVeJrCNMOOw")
+                initializeOmni("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjaGFudCI6ImViNDhlZjk5LWFhNzgtNDk2ZS05YjAxLTQyMWY4ZGFmNzMyMyIsImdvZFVzZXIiOnRydWUsImJyYW5kIjoiZmF0dG1lcmNoYW50Iiwic3ViIjoiMTI4MGRkNGQtMTI2MS00YWI1LThkZmItY2FmMWY3ZDhjZTM0IiwiaXNzIjoiaHR0cDovL2FwaWRldjAxLmZhdHRsYWJzLmNvbS9hdXRoZW50aWNhdGUiLCJpYXQiOjE2MTQxMTM1NDMsImV4cCI6MTYxNDE5OTk0MywibmJmIjoxNjE0MTEzNTQzLCJqdGkiOiJ0THZiVWlkZW55UkF6aDNnIn0.p2_9RVIpsfcDbJOKJ2trsqXqpnpPPpLR3fOQwnkEMqA")
             }.show()
     }
 

--- a/cardpresent/src/main/java/com/fattmerchant/android/anywherecommerce/AWCDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/anywherecommerce/AWCDriver.kt
@@ -15,6 +15,7 @@ import com.anywherecommerce.android.sdk.transactions.listener.TransactionListene
 import com.fattmerchant.omni.MobileReaderConnectionStatusListener
 import com.fattmerchant.omni.SignatureProviding
 import com.fattmerchant.omni.TransactionUpdateListener
+import com.fattmerchant.omni.UserNotificationListener
 import com.fattmerchant.omni.data.*
 import com.fattmerchant.omni.data.models.Transaction
 import com.fattmerchant.omni.data.MobileReaderDriver.*
@@ -147,7 +148,7 @@ internal class AWCDriver: MobileReaderDriver {
 
     var transactionUpdateDelay = 0.0
 
-    override suspend fun performTransaction(request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateListener: TransactionUpdateListener?): TransactionResult {
+    override suspend fun performTransaction(request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateListener: TransactionUpdateListener?, userNotificationListener: UserNotificationListener?): TransactionResult {
         return suspendCancellableCoroutine { cancellableContinuation ->
             // Create AnyPayTransaction
             val transaction = AnyPayTransaction()

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -2,12 +2,8 @@ package com.fattmerchant.android.chipdna
 
 import android.content.Context
 import com.creditcall.chipdnamobile.*
-import com.fattmerchant.omni.MobileReaderConnectionStatusListener
-import com.fattmerchant.omni.OmniGeneralException
-import com.fattmerchant.omni.SignatureProviding
-import com.fattmerchant.omni.TransactionUpdateListener
+import com.fattmerchant.omni.*
 import com.fattmerchant.omni.data.*
-import com.fattmerchant.omni.data.models.Merchant
 import com.fattmerchant.omni.data.models.Transaction
 import com.fattmerchant.omni.data.MobileReaderDriver.*
 import com.fattmerchant.omni.data.models.MobileReaderConnectionStatus
@@ -243,8 +239,8 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver, IConfiguratio
         return true
     }
 
-    override suspend fun performTransaction(request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateListener: TransactionUpdateListener?): TransactionResult {
-        val paymentRequestParams = Parameters().withTransactionRequest(request)
+    override suspend fun performTransaction(request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateListener: TransactionUpdateListener?, userNotificationListener: UserNotificationListener?): TransactionResult {
+        val paymentRequestParams = withTransactionRequest(request)
 
         val result = suspendCancellableCoroutine<Parameters> { cont ->
 
@@ -263,6 +259,7 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver, IConfiguratio
 
             transactionListener.signatureProvider = signatureProvider
             transactionListener.transactionUpdateListener = transactionUpdateListener
+            transactionListener.userNotificationListener = userNotificationListener
             ChipDnaMobile.getInstance().addUserNotificationListener(transactionListener)
             ChipDnaMobile.getInstance().addApplicationSelectionListener(transactionListener)
             ChipDnaMobile.getInstance().addTransactionUpdateListener(transactionListener)

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaTransactionListener.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaTransactionListener.kt
@@ -3,6 +3,7 @@ package com.fattmerchant.android.chipdna
 import com.creditcall.chipdnamobile.*
 import com.fattmerchant.omni.SignatureProviding
 import com.fattmerchant.omni.TransactionUpdateListener
+import com.fattmerchant.omni.UserNotificationListener
 import com.fattmerchant.omni.data.TransactionUpdate
 
 internal class ChipDnaTransactionListener : ITransactionUpdateListener, ITransactionFinishedListener,
@@ -17,6 +18,9 @@ internal class ChipDnaTransactionListener : ITransactionUpdateListener, ITransac
 
     /** Gets notified of transaction events */
     var transactionUpdateListener: TransactionUpdateListener? = null
+
+    /** Gets notified of user notifications */
+    var userNotificationListener: UserNotificationListener? = null
 
     override fun onTransactionFinishedListener(parameters: Parameters) {
         onFinish?.invoke(parameters)
@@ -57,11 +61,19 @@ internal class ChipDnaTransactionListener : ITransactionUpdateListener, ITransac
         }
     }
 
+    override fun onUserNotification(parameters: Parameters?) {
+        parameters?.getValue(ParameterKeys.UserNotification)?.let {
+            userNotificationListener?.onRawUserNotification(it)
+            mapUserNotification(it)?.let { userNotification ->
+                userNotificationListener?.onUserNotification(userNotification)
+            }
+        }
+    }
+
     override fun onVoiceReferral(parameters: Parameters) {}
     override fun onVerifyId(parameters: Parameters) {}
     override fun onDeferredAuthorizationListener(parameters: Parameters) {}
     override fun onForceAcceptance(parameters: Parameters) {}
     override fun onPartialApproval(parameters: Parameters) {}
     override fun onApplicationSelection(p0: Parameters?) {}
-    override fun onUserNotification(p0: Parameters?) {}
 }

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
@@ -1,19 +1,19 @@
 package com.fattmerchant.android.chipdna
 
-import android.bluetooth.BluetoothClass
 import com.creditcall.chipdnamobile.DeviceStatus
 import com.creditcall.chipdnamobile.ParameterKeys
 import com.creditcall.chipdnamobile.ParameterValues
 import com.creditcall.chipdnamobile.Parameters
-import com.creditcall.chipdnamobile.TransactionUpdate as ChipDnaTransactionUpdate
-import com.fattmerchant.android.chipdna.ChipDnaDriver
 import com.fattmerchant.omni.data.MobileReader
 import com.fattmerchant.omni.data.TransactionRequest
 import com.fattmerchant.omni.data.TransactionUpdate
+import com.fattmerchant.omni.data.UserNotification
 import com.fattmerchant.omni.data.models.MobileReaderConnectionStatus
 import com.fattmerchant.omni.data.models.Transaction
 import java.text.SimpleDateFormat
 import java.util.*
+import com.creditcall.chipdnamobile.TransactionUpdate as ChipDnaTransactionUpdate
+import com.creditcall.chipdnamobile.UserNotification as ChipDnaUserNotification
 
 /**
  * Makes an instance of [MobileReader] for the given [pinPad]
@@ -67,6 +67,27 @@ fun mapTransactionUpdate(transactionUpdate: String): TransactionUpdate? {
 }
 
 /**
+ * Maps a ChipDna UserNotification to an Omni UserNotification
+ *
+ * @param userNotification the value of a ChipDnaUserNotification
+ * @return an Omni [UserNotification]
+ */
+fun mapUserNotification(userNotification: String): UserNotification? {
+    return when (userNotification) {
+        ChipDnaUserNotification.TryCardAgain.value -> UserNotification.TryCardAgain
+        ChipDnaUserNotification.ChipReadErrorApplicationNotSupportedPleaseRetry.value -> UserNotification.ChipReadErrorApplicationNotSupportedPleaseRetry
+        ChipDnaUserNotification.ICCFallforward.value -> UserNotification.FallforwardInsertCard
+        ChipDnaUserNotification.ICCMSRFallforward.value -> UserNotification.FallforwardInsertSwipeCard
+        ChipDnaUserNotification.MSRFallback.value -> UserNotification.FallbackSwipeCard
+        ChipDnaUserNotification.MSRFallforward.value -> UserNotification.FallforwardSwipeCard
+        ChipDnaUserNotification.PresentOneCardOnly.value -> UserNotification.PresentOneCardOnly
+        ChipDnaUserNotification.ReferToDevice.value -> UserNotification.ReferToDevice
+        else -> UserNotification(userNotification)
+    }
+}
+
+
+/**
  * Tries to get the parameter by key.
  *
  * @return null if not found
@@ -107,7 +128,7 @@ internal fun extractCardEaseReference(transaction: Transaction): String? =
 internal fun generateUserReference(): String =
         String.format("CDM-%s", SimpleDateFormat("yy-MM-dd-HH.mm.ss", Locale.US).format(Date()))
 
-internal fun Parameters.withTransactionRequest(request: TransactionRequest) = Parameters().apply {
+internal fun withTransactionRequest(request: TransactionRequest) = Parameters().apply {
     add(ParameterKeys.Amount, request.amount.centsString())
     add(ParameterKeys.AmountType, ParameterValues.AmountTypeActual)
     add(ParameterKeys.Currency, "USD")

--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -45,6 +45,9 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
     /** Receives notifications about transaction events such as when a card is swiped */
     open var transactionUpdateListener: TransactionUpdateListener? = null
 
+    /** Receives user notifications that are used for prompts */
+    open var userNotificationListener: UserNotificationListener? = null
+
     /** Receives notifications about reader connection events */
     open var mobileReaderConnectionStatusListener: MobileReaderConnectionStatusListener? = null
 
@@ -63,7 +66,9 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
 
             val merchant = omniApi.getSelf {
                 error(OmniException("Could not get reader settings", it.message))
-            }?.merchant ?: return@launch
+            }?.merchant ?: run {
+                error(error(OmniException("Could not get reader settings", "Merchant object is null")))
+            }
 
             val mutatedArgs = args.toMutableMap()
 
@@ -278,6 +283,7 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
                     request = request,
                     signatureProvider = signatureProvider,
                     transactionUpdateListener = transactionUpdateListener,
+                    userNotificationListener = userNotificationListener,
                     coroutineContext = coroutineContext
             )
 

--- a/cardpresent/src/main/java/com/fattmerchant/omni/UserNotificationListener.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/UserNotificationListener.kt
@@ -1,7 +1,6 @@
 package com.fattmerchant.omni
 
 import com.fattmerchant.omni.data.UserNotification
-import com.creditcall.chipdnamobile.UserNotification as ChipDnaUserNotification
 
 /**
  * Listens to user notification updates
@@ -37,7 +36,6 @@ interface UserNotificationListener {
      * *FallforwardInsertSwipeCard* - Indicates that fallforward from Contactless to Insert/Swipe has occurred.
      *
      * *TryCardAgain* - Indicates that the card should be tried again.
-     * @see ChipDnaUserNotification
      */
     fun onRawUserNotification(userNotification: String)
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/UserNotificationListener.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/UserNotificationListener.kt
@@ -1,0 +1,43 @@
+package com.fattmerchant.omni
+
+import com.fattmerchant.omni.data.UserNotification
+import com.creditcall.chipdnamobile.UserNotification as ChipDnaUserNotification
+
+/**
+ * Listens to user notification updates
+ *
+ * Fired when a prompt is required to be shown to the customer.
+ *
+ * @see UserNotification
+ */
+interface UserNotificationListener {
+    /**
+     * Called when a prompt is required to be shown to a customer and returns a [UserNotification]
+     * @see UserNotification
+     */
+    fun onUserNotification(userNotification: UserNotification)
+
+    /**
+     * Called when a prompt is required to be shown to a customer and returns the raw value from ChipDNA
+     *
+     * Possible values include:
+     *
+     * *ReferToDevice* - Indicates referral to the device.
+     *
+     * *ChipReadErrorApplicationNotSupportedPleaseRetry* - Indicates there has been an issue with the ICC chip and the user should retry.
+     *
+     * *PresentOneCardOnly* - Indicates that only one card should be presented.
+     *
+     * *FallbackSwipeCard* - Indicates that fallback to Swipe has occurred.
+     *
+     * *FallforwardSwipeCard* - Indicates that fallforward from Contactless to Swipe has occurred.
+     *
+     * *FallforwardInsertCard* - Indicates that fallforward from Contactless to Insert has occurred.
+     *
+     * *FallforwardInsertSwipeCard* - Indicates that fallforward from Contactless to Insert/Swipe has occurred.
+     *
+     * *TryCardAgain* - Indicates that the card should be tried again.
+     * @see ChipDnaUserNotification
+     */
+    fun onRawUserNotification(userNotification: String)
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/MobileReaderDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/MobileReaderDriver.kt
@@ -3,6 +3,7 @@ package com.fattmerchant.omni.data
 import com.fattmerchant.omni.MobileReaderConnectionStatusListener
 import com.fattmerchant.omni.SignatureProviding
 import com.fattmerchant.omni.TransactionUpdateListener
+import com.fattmerchant.omni.UserNotificationListener
 import com.fattmerchant.omni.data.models.OmniException
 import com.fattmerchant.omni.data.models.Transaction
 import com.fattmerchant.omni.usecase.CancelCurrentTransactionException
@@ -105,7 +106,9 @@ internal interface MobileReaderDriver {
      * @return the result of the operation
      */
     @Throws(PerformTransactionException::class)
-    suspend fun performTransaction(request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateListener: TransactionUpdateListener?): TransactionResult
+    suspend fun performTransaction(request: TransactionRequest, signatureProvider: SignatureProviding?,
+                                   transactionUpdateListener: TransactionUpdateListener?,
+                                   userNotificationListener: UserNotificationListener?): TransactionResult
 
     /**
      * Attempts to void the given [transaction]

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/UserNotification.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/UserNotification.kt
@@ -1,0 +1,35 @@
+package com.fattmerchant.omni.data
+
+/**
+ * Represents a user notification
+ *
+ * This object will provide information about events that prompt the user.
+ */
+open class UserNotification(var value: String, val userFriendlyMessage: String? = null) {
+    companion object {
+        /** Indicates referral to the device */
+        val ReferToDevice = UserNotification("Prompt User Refer To Device", "Please check your device.")
+
+        /** Indicates there has been an issue with the ICC chip and the user should retry */
+        val ChipReadErrorApplicationNotSupportedPleaseRetry = UserNotification("Prompt User Error Application Not Supported",
+                "There was an error with processing the chip card. Please try again.")
+
+        /** Indicates that only one card should be presented */
+        val PresentOneCardOnly = UserNotification("Prompt User Present One Card Only", "Please only present one card.")
+
+        /** Indicates that fallback to Swipe has occurred */
+        val FallbackSwipeCard = UserNotification("Prompt User Fallback Swipe Card", "Please swipe your card.")
+
+        /** Indicates that fallforward from Contactless to Swipe has occurred */
+        val FallforwardSwipeCard = UserNotification("Prompt User Fallforward Swipe Card", "Please swipe your card.")
+
+        /** Indicates that fallforward from Contactless to Insert has occurred */
+        val FallforwardInsertCard = UserNotification("Prompt User Fallback Insert Card", "Please insert your card.")
+
+        /** Indicates that fallforward from Contactless to Insert/Swipe has occurred */
+        val FallforwardInsertSwipeCard = UserNotification("Prompt User Fallforward Insert Swipe Card", "Please insert or swipe your card.")
+
+        /** Indicates that the card should be tried again */
+        val TryCardAgain = UserNotification( "Prompt User Try Card Again","Please try your card again.")
+    }
+}

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/UserNotification.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/UserNotification.kt
@@ -20,13 +20,13 @@ open class UserNotification(var value: String, val userFriendlyMessage: String? 
         /** Indicates that fallback to Swipe has occurred */
         val FallbackSwipeCard = UserNotification("Prompt User Fallback Swipe Card", "Please swipe your card.")
 
-        /** Indicates that fallforward from Contactless to Swipe has occurred */
+        /** Indicates that fallforward to Swipe has occurred */
         val FallforwardSwipeCard = UserNotification("Prompt User Fallforward Swipe Card", "Please swipe your card.")
 
-        /** Indicates that fallforward from Contactless to Insert has occurred */
-        val FallforwardInsertCard = UserNotification("Prompt User Fallback Insert Card", "Please insert your card.")
+        /** Indicates that fallforward to Insert has occurred */
+        val FallforwardInsertCard = UserNotification("Prompt User Fallforward Insert Card", "Please insert your card.")
 
-        /** Indicates that fallforward from Contactless to Insert/Swipe has occurred */
+        /** Indicates that fallforward to Insert/Swipe has occurred */
         val FallforwardInsertSwipeCard = UserNotification("Prompt User Fallforward Insert Swipe Card", "Please insert or swipe your card.")
 
         /** Indicates that the card should be tried again */

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
@@ -4,6 +4,7 @@ import com.fattmerchant.android.anywherecommerce.AWCDriver
 import com.fattmerchant.android.chipdna.ChipDnaDriver
 import com.fattmerchant.omni.SignatureProviding
 import com.fattmerchant.omni.TransactionUpdateListener
+import com.fattmerchant.omni.UserNotificationListener
 import com.fattmerchant.omni.data.*
 import com.fattmerchant.omni.data.models.*
 import com.fattmerchant.omni.data.repository.*
@@ -20,6 +21,7 @@ internal class TakeMobileReaderPayment(
     val request: TransactionRequest,
     val signatureProvider: SignatureProviding? = null,
     val transactionUpdateListener: TransactionUpdateListener? = null,
+    val userNotificationListener: UserNotificationListener? = null,
     override val coroutineContext: CoroutineContext
 ) : CoroutineScope {
 
@@ -97,7 +99,7 @@ internal class TakeMobileReaderPayment(
         val result: TransactionResult
 
         try {
-            result = reader.performTransaction(request, signatureProvider, transactionUpdateListener)
+            result = reader.performTransaction(request, signatureProvider, transactionUpdateListener, userNotificationListener)
         } catch (e: MobileReaderDriver.PerformTransactionException) {
             onError(TakeMobileReaderPaymentException(e.detail))
             return@coroutineScope null

--- a/cardpresent/src/test/java/com/fattmerchant/omni/chipdna/ChipDnaUtilsTest.kt
+++ b/cardpresent/src/test/java/com/fattmerchant/omni/chipdna/ChipDnaUtilsTest.kt
@@ -2,7 +2,6 @@ package com.fattmerchant.omni.chipdna
 
 
 import com.creditcall.chipdnamobile.ParameterKeys
-import com.creditcall.chipdnamobile.Parameters
 import com.fattmerchant.android.chipdna.extractUserReference
 import com.fattmerchant.android.chipdna.withTransactionRequest
 import com.fattmerchant.omni.data.Amount
@@ -19,7 +18,7 @@ class ChipDnaUtilsTest {
     @Test
     fun `adds customer vault request parameter if tokenization requested`() {
         val request = TransactionRequest(amount)
-        val params = Parameters().withTransactionRequest(request)
+        val params = withTransactionRequest(request)
         assert(params.containsKey(ParameterKeys.CustomerVaultCommand))
     }
 
@@ -32,7 +31,7 @@ class ChipDnaUtilsTest {
     @Test
     fun `does not add customer vault request parameter if tokenization not requested`() {
         val request = TransactionRequest(amount, false)
-        val params = Parameters().withTransactionRequest(request)
+        val params = withTransactionRequest(request)
         assertFalse(params.containsKey(ParameterKeys.CustomerVaultCommand))
     }
 


### PR DESCRIPTION
## **[Ticket MOB-562](https://fattmerchant.atlassian.net/browse/MOB-562)**
> **Android SDK | NMI bbPOS | On screen prompts**
## What did I do?
* Created a `UserNotification` object to map user notification response from ChipDNA to readable type
* Create a `UserNotificationListener` which is used to respond to the callbacks from ChipDNA user notifications
* Passed `UserNotificationListener` to `TakeMobileReaderPayment` usecase

---

<!-- YOU CAN DELETE THE SCREENSHOTS SECTION IF NOT APPLICABLE -->
## Screenshot(s):
<img width="599" alt="Screen Shot 2021-02-23 at 4 15 39 PM" src="https://user-images.githubusercontent.com/10945265/108910070-59430800-75f3-11eb-879b-87881cc92253.png">

---

## PR notes contain:
* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)
## PR Checklist:
* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
