### PR TITLE
[SPRINT-172][MOB-625] Suspendable connectReader

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -197,6 +197,7 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver, IConfiguratio
 
     override suspend fun disconnect(reader: MobileReader, error: (OmniException) -> Unit): Boolean {
         ChipDnaMobile.dispose(null)
+        mobileReaderConnectionStatusListener?.mobileReaderConnectionStatusUpdate(MobileReaderConnectionStatus.DISCONNECTED)
         initialize(initArgs)
         return true
     }

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -186,15 +186,6 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver, IConfiguratio
                     return@IConnectAndConfigureFinishedListener
                 }
 
-                if(params.containsKey(ParameterKeys.Errors)) {
-                    if(params[ParameterKeys.Errors]?.contains("DeviceRebooting") == true) {
-                        ChipDnaMobile.getInstance().addConnectAndConfigureFinishedListener(connectAndConfigureListener)
-                        ChipDnaMobile.getInstance().connectAndConfigure(requestParams)
-                    }
-
-                    return@IConnectAndConfigureFinishedListener
-                }
-
                 val error = params[ParameterKeys.ErrorDescription]
                 cont.resumeWithException(ConnectReaderException(error))
             }

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -186,6 +186,15 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver, IConfiguratio
                     return@IConnectAndConfigureFinishedListener
                 }
 
+                if(params.containsKey(ParameterKeys.Errors)) {
+                    if(params[ParameterKeys.Errors]?.contains("DeviceRebooting") == true) {
+                        ChipDnaMobile.getInstance().addConnectAndConfigureFinishedListener(connectAndConfigureListener)
+                        ChipDnaMobile.getInstance().connectAndConfigure(requestParams)
+                    }
+
+                    return@IConnectAndConfigureFinishedListener
+                }
+
                 val error = params[ParameterKeys.ErrorDescription]
                 cont.resumeWithException(ConnectReaderException(error))
             }

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
@@ -167,5 +167,6 @@ fun MobileReaderConnectionStatus.Companion.from(chipDnaConfigurationUpdate: Stri
 
 fun MobileReaderConnectionStatus.Companion.from(chipDnaDeviceStatus: DeviceStatus.DeviceStatusEnum) = when(chipDnaDeviceStatus) {
     DeviceStatus.DeviceStatusEnum.DeviceStatusDisconnected -> MobileReaderConnectionStatus.DISCONNECTED
+    DeviceStatus.DeviceStatusEnum.DeviceStatusConnected -> MobileReaderConnectionStatus.CONNECTED
     else -> null
 }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -170,6 +170,20 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
     }
 
     /**
+     * Attempts to connect to the given [MobileReader]
+     *
+     * returns a [MobileReader]
+     */
+    suspend fun connectReader(mobileReader: MobileReader): MobileReader? = withContext(Dispatchers.Main){
+        return@withContext ConnectMobileReader(
+                coroutineContext,
+                mobileReaderDriverRepository,
+                mobileReader,
+                mobileReaderConnectionStatusListener
+        ).start()
+    }
+
+    /**
      * Attempts to disconnect the given [MobileReader]
      *
      * @param mobileReader the [MobileReader] to disconnect


### PR DESCRIPTION
## **[Ticket MOB-625](https://fattmerchant.atlassian.net/browse/MOB-625)**
> **Android SDK | Create a suspendable version of connect reader and pass back DISCONNECTED and CONNECTED statuses**
## What did I do?
* Created a suspendable version of connectReader function that allows us to use it directly in a background work manager managed with coroutine scope.
* Pass back statuses for CONNECTED and DISCONNECTED that were previously not firing
---

## PR notes contain:
* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)
## PR Checklist:
* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
