### PR TITLE
[SPRINT-180][MOB-743] Throw exception when invoice id is blank

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
@@ -79,7 +79,7 @@ internal class TakeMobileReaderPayment(
         // Check if we are passing an invoice id
         request.invoiceId?.let {
             if (it.isBlank()) {
-                onError(TakeMobileReaderPaymentException("Cannot pass blank invoice id."))
+                onError(TakeMobileReaderPaymentException("Could not create invoice."))
                 return@coroutineScope  null
             }
             // Check if the invoice exists

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
@@ -78,6 +78,10 @@ internal class TakeMobileReaderPayment(
 
         // Check if we are passing an invoice id
         request.invoiceId?.let {
+            if (it.isBlank()) {
+                onError(TakeMobileReaderPaymentException("Cannot pass blank invoice id."))
+                return@coroutineScope  null
+            }
             // Check if the invoice exists
             invoice = invoiceRepository.getById(it) {
                 onError(TakeMobileReaderPaymentException("Invoice with given id not found"))


### PR DESCRIPTION
## **[Ticket MOB-743](https://fattmerchant.atlassian.net/browse/MOB-743)**
> **Android SDK 2.0.0 | Taking a payment with an invoice of "" will show as successful in transactiongateway but will not show up at all in Stax**

## What did I do?
* Added a check before continuing with the transaction if the invoice id has any blank characters.
---
<!-- YOU CAN DELETE THE SCREENSHOTS SECTION IF NOT APPLICABLE -->
## Screenshot(s):
<img width="598" alt="Screen Shot 2021-04-30 at 12 02 14 PM" src="https://user-images.githubusercontent.com/10945265/116722331-40b4ec80-a9ac-11eb-8dc3-5801fa1ee0b2.png">

---

## PR notes contain:
* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)

## PR Checklist:
* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
