### PR TITLE
[SPRINT-185][MOB-779] Wrap transactions with auth + cap

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -314,6 +314,17 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
         }
     }
 
+    override suspend fun capture(transaction: Transaction): Boolean {
+        val userRef = extractUserReference(transaction) ?: return false
+
+        val params = Parameters().apply {
+            add(ParameterKeys.UserReference, userRef)
+        }
+
+        val result = ChipDnaMobile.getInstance().confirmTransaction(params)
+        return result[ParameterKeys.Result] == ParameterValues.Approved
+    }
+
     override suspend fun voidTransaction(transaction: Transaction): TransactionResult {
         val ref = extractCardEaseReference(transaction)
 

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -339,6 +339,17 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
         return TransactionResult()
     }
 
+    override fun voidTransaction(transactionResult: TransactionResult, completion: (Boolean) -> Unit) {
+        val userRef = transactionResult.userReference ?: return completion(false)
+
+        val params = Parameters().apply {
+            add(ParameterKeys.UserReference, userRef)
+        }
+
+        val result = ChipDnaMobile.getInstance().voidTransaction(params)
+        completion(result[ParameterKeys.Result] == ParameterValues.Approved)
+    }
+
     override suspend fun refundTransaction(transaction: Transaction, refundAmount: Amount?): TransactionResult {
         // Prepare Parameters for refunding
         val ref = extractCardEaseReference(transaction)

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaDriver.kt
@@ -101,7 +101,6 @@ internal class ChipDnaDriver : CoroutineScope, MobileReaderDriver {
 
         val params = Parameters().apply {
             add(ParameterKeys.Password, "password")
-            add(ParameterKeys.AutoConfirm, ParameterValues.TRUE)
         }
 
         // Init

--- a/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/chipdna/ChipDnaUtils.kt
@@ -111,7 +111,6 @@ internal fun Parameters.withTransactionRequest(request: TransactionRequest) = Pa
     add(ParameterKeys.Currency, "USD")
     add(ParameterKeys.UserReference, generateUserReference())
     add(ParameterKeys.PaymentMethod, ParameterValues.Card)
-    add(ParameterKeys.AutoConfirm, ParameterValues.TRUE)
     add(ParameterKeys.TransactionType, ParameterValues.Sale)
 
     if (request.tokenize) {

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/MobileReaderDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/MobileReaderDriver.kt
@@ -80,6 +80,11 @@ internal interface MobileReaderDriver {
     suspend fun performTransaction(request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateListener: TransactionUpdateListener?): TransactionResult
 
     /**
+     * Captures an auth transaction
+     */
+    suspend fun capture(transaction: Transaction): Boolean
+
+    /**
      * Attempts to void the given [transaction]
      *
      * @param transaction

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/MobileReaderDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/MobileReaderDriver.kt
@@ -94,6 +94,15 @@ internal interface MobileReaderDriver {
     suspend fun voidTransaction(transaction: Transaction): TransactionResult
 
     /**
+     * Attempts to void the transaction referenced in the transaction result
+     *
+     * @param transaction
+     * @return the result of the operation
+     */
+    @Throws(VoidTransactionException::class)
+    fun voidTransaction(transactionResult: TransactionResult, completion: (Boolean) -> Unit)
+
+    /**
      * Attempts to refund the given [transaction]
      *
      * @param transaction


### PR DESCRIPTION
## **[Ticket MOB-779](https://fattmerchant.atlassian.net/browse/MOB-779)**
> **ANDROID SDK -[EFS][EPS][NMI][AWC][BBPOS] Transactions not getting created initially when ran on mobile reader**
## What did I do?
* Make transactions not get autoconfirmed by NMI
* Wrap each transaction with auth+capture such that the transaction doesn't _actually_ get captured until Stax has all the necessary records created

Note that this is the same change we did for iOS SDK 

---
## PR notes contain:
* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)
## PR Checklist:
* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
