### PR TITLE
[SPRINT-190] [MOB-859] Fix AWC crash

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/anywherecommerce/AWCDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/anywherecommerce/AWCDriver.kt
@@ -37,6 +37,8 @@ internal class AWCDriver: MobileReaderDriver {
     /** The transaction currently underway */
     private var currentTransaction: AnyPayTransaction? = null
 
+    private var missingAwcDetails: Boolean = true
+
     override val source: String = "AWC"
 
     override var familiarSerialNumbers: MutableList<String> = mutableListOf()
@@ -68,6 +70,11 @@ internal class AWCDriver: MobileReaderDriver {
         val awcArgs = args["awc"] as? MobileReaderDetails.AWCDetails
                 ?: throw InitializeMobileReaderDriverException("merchant not found")
 
+        if (awcArgs.terminalId.isBlank() || awcArgs.terminalSecret.isBlank()) {
+            missingAwcDetails = true
+            throw InitializeMobileReaderDriverException("merchant not foundq")
+        }
+
         // Initialize the Terminal. This will allow us to interact with AnyPay later on
         SDKManager.initialize(application)
         Terminal.initialize()
@@ -98,7 +105,12 @@ internal class AWCDriver: MobileReaderDriver {
 
     }
 
-    override suspend fun isInitialized(): Boolean = Terminal.isInitialized() && endpoint != null
+    override suspend fun isInitialized(): Boolean {
+        if (missingAwcDetails) {
+            return false
+        }
+        return Terminal.isInitialized() && endpoint != null
+    }
 
     override suspend fun searchForReaders(args: Map<String, Any>): List<MobileReader> {
         return suspendCancellableCoroutine {


### PR DESCRIPTION
## **[Ticket MOB-859](https://fattmerchant.atlassian.net/browse/MOB-859)**
> **Android 2.1.1 | AWC crash on initialize**

## What did I do?
* Prevented invocations of AWC methods if AWC creds not provided

## PR notes contain:
* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)

## PR Checklist:
* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
