### PR TITLE
[SPRINT-197][MOB-959] Add shippingAmount and poNumber to TransactionRequest

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionRequest.kt
@@ -48,6 +48,12 @@ data class TransactionRequest(
     /** The tip amount applied to the transaction */
     var tip: Double? = null,
 
+    /** The shipping amount applied to the transaction */
+    var shippingAmount: Double? = null,
+
+    /** The purchase order number for the transaction */
+    var poNumber: String? = null,
+
     /** A memo for the transaction */
     var memo: String? = null,
 

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/TakeMobileReaderPayment.kt
@@ -60,6 +60,8 @@ internal class TakeMobileReaderPayment(
             result.request?.tip?.let { transactionMeta["tip"] = it }
             result.request?.memo?.let { transactionMeta["memo"] = it }
             result.request?.reference?.let { transactionMeta["reference"] = it }
+            result.request?.shippingAmount?.let { transactionMeta["shippingAmount"] = it }
+            result.request?.poNumber?.let { transactionMeta["poNumber"] = it }
 
             return transactionMeta
         }
@@ -73,6 +75,8 @@ internal class TakeMobileReaderPayment(
             result.request?.tip?.let { invoiceMeta["tip"] = it }
             result.request?.memo?.let { invoiceMeta["memo"] = it }
             result.request?.reference?.let { invoiceMeta["reference"] = it }
+            result.request?.shippingAmount?.let { invoiceMeta["shippingAmount"] = it }
+            result.request?.poNumber?.let { invoiceMeta["poNumber"] = it }
 
             return invoiceMeta
         }


### PR DESCRIPTION
## **[Ticket MOB-959](https://fattmerchant.atlassian.net/browse/MOB-959)**
> **Android SDK 2.2.0 | Add shipping amount and po number to TransactionRequest**

## What did I do?
* Added `shippingAmount` and `poNumber` to TransactionRequest
---

## PR notes contain:
* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)

## PR Checklist:
* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
