### PR TITLE
Mob 1074 void payment

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/android/dejavoo/DejavooDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/dejavoo/DejavooDriver.kt
@@ -179,7 +179,7 @@ class DejavooDriver : CoroutineScope, PaymentTerminalDriver {
                                 "RespMSG" to response.responseMessage,
                                 "SN" to response.serialNumber,
                             )
-                            transactionType = "refund"
+                            transactionType = "void"
                             this.request = request
                         }
 
@@ -226,8 +226,6 @@ class DejavooDriver : CoroutineScope, PaymentTerminalDriver {
                         val firstName = names.first()
                         val lastName = names.last()
                         val expiry = extData.data["ExpDate"] ?: "1299"
-
-                        response.referenceId // this seems like the transaction ref id to use for voiding/refunding
 
                         val transactionResult = TransactionResult().apply {
                             authCode = auth

--- a/cardpresent/src/main/java/com/fattmerchant/android/dejavoo/DejavooDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/dejavoo/DejavooDriver.kt
@@ -134,6 +134,9 @@ class DejavooDriver : CoroutineScope, PaymentTerminalDriver {
 
         return suspendCancellableCoroutine { cancellableContinuation ->
             val dejavooRequest = DejavooTransactionRequest()
+            dejavooRequest.authenticationKey = authenticationKey
+            dejavooRequest.tpn = tpn
+            dejavooRequest.registerId = registerId
             dejavooRequest.paymentType = DejavooPaymentType.Credit
             dejavooRequest.transactionType = DejavooTransactionType.Void
             dejavooRequest.referenceId = referenceId
@@ -202,6 +205,9 @@ class DejavooDriver : CoroutineScope, PaymentTerminalDriver {
 
         return suspendCancellableCoroutine { cancellableContinuation ->
             val dejavooRequest = DejavooTransactionRequest()
+            dejavooRequest.authenticationKey = authenticationKey
+            dejavooRequest.tpn = tpn
+            dejavooRequest.registerId = registerId
             dejavooRequest.paymentType = DejavooPaymentType.Credit
             dejavooRequest.transactionType = DejavooTransactionType.Return
             dejavooRequest.referenceId = referenceId

--- a/cardpresent/src/main/java/com/fattmerchant/android/dejavoo/DejavooDriver.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/android/dejavoo/DejavooDriver.kt
@@ -87,9 +87,17 @@ class DejavooDriver : CoroutineScope, PaymentTerminalDriver {
                         val lastFour = extData.acntLast4
                         val pan = "$firstFour********$lastFour"
                         val names = extData.cardHolder.split("/").reversed()
-                        val firstName = names.first()
-                        val lastName = names.last()
+                        var firstName = names.first()
+                        var lastName = names.last()
                         val expiry = extData.data["ExpDate"] ?: "1299"
+
+                        if (firstName.isBlank()) {
+                            firstName = "Contactless"
+                        }
+
+                        if (lastName.isBlank()) {
+                            lastName = "Customer"
+                        }
 
                         val transactionResult = TransactionResult().apply {
                             authCode = auth
@@ -152,11 +160,19 @@ class DejavooDriver : CoroutineScope, PaymentTerminalDriver {
                         val lastFour = extData.acntLast4
                         val pan = "$firstFour********$lastFour"
                         val names = extData.cardHolder.split("/").reversed()
-                        val firstName = names.first()
-                        val lastName = names.last()
+                        var firstName = names.first()
+                        var lastName = names.last()
                         val expiry = extData.data["ExpDate"] ?: "1299"
 
                         response.referenceId // this seems like the transaction ref id to use for voiding/refunding
+
+                        if (firstName.isBlank()) {
+                            firstName = "Contactless"
+                        }
+
+                        if (lastName.isBlank()) {
+                            lastName = "Customer"
+                        }
 
                         val transactionResult = TransactionResult().apply {
                             authCode = auth
@@ -223,9 +239,18 @@ class DejavooDriver : CoroutineScope, PaymentTerminalDriver {
                         val lastFour = extData.acntLast4
                         val pan = "$firstFour********$lastFour"
                         val names = extData.cardHolder.split("/").reversed()
-                        val firstName = names.first()
-                        val lastName = names.last()
+                        var firstName = names.first()
+                        var lastName = names.last()
                         val expiry = extData.data["ExpDate"] ?: "1299"
+
+
+                        if (firstName.isBlank()) {
+                            firstName = "Contactless"
+                        }
+
+                        if (lastName.isBlank()) {
+                            lastName = "Customer"
+                        }
 
                         val transactionResult = TransactionResult().apply {
                             authCode = auth


### PR DESCRIPTION
## **[Ticket MOB-1074](https://fattmerchant.atlassian.net/browse/MOB-1074)**
> **Fix Refund/Void bug for Dejavoo**
## What did I do?
We use Dejavoo's DejaPay SDK in order to send payment intents to Dejavoo's payment app, Aura. Our integration of DejaPay works perfectly fine on Engineering Mode terminals, but when deployed onto a live terminal, refunds no longer work. DejaPay also doesn't throw any errors for refunds when running on an Engineering Mode terminal, so we had no help from it to see what was going on.

What we did find, however, is that we were missing some parameters in the request to refund/void, as per this document
![DFD7861A-FAB0-4BD0-8ADE-13249CF9F074](https://user-images.githubusercontent.com/5385681/168069357-f2552dd5-2987-4bf5-92a3-c5b2b53c3602.png). https://dejavoosystems.atlassian.net/wiki/spaces/DOC/pages/3250946049/Examples+of+Credit+Debit+requests

What I did in order to fix this is to simply add the missing params and run a bunch of transactions and verify they still refund/void
