### PR TITLE
[SPRINT-231][MOB-1247] Initialize SDK without mobile reader credentials

### DIFF
--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -91,7 +91,7 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
             }
 
             omniApi.getMobileReaderSettings {
-                // error(OmniException("Could not get reader settings", it.message))
+                 error(OmniException("Could not get reader settings", it.message))
             }?.let { mobileReaderDetails ->
                 mobileReaderDetails.nmi?.let {
                     mutatedArgs["nmi"] = it
@@ -100,16 +100,21 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
                 mobileReaderDetails.anywhereCommerce?.let {
                     mutatedArgs["awc"] = it
                 }
+
+                // In case of Missing reader credentials
+                if (mutatedArgs["awc"] == null && mutatedArgs["nmi"] == null) {
+                    initialized = true
+                    error(OmniException("Could not get reader settings", "Your account does not have mobile reader credentials"))
+                    return@launch
+                }
             }
 
+            initialized = true
             InitializeDrivers(
                 mobileReaderDriverRepository,
                 mutatedArgs,
                 coroutineContext
             ).start(error)
-
-            initialized = true
-
             completion()
         }
     }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/Omni.kt
@@ -107,7 +107,7 @@ open class Omni internal constructor(internal var omniApi: OmniApi) {
             var updatedAWCDetails: MobileReaderDetails.AWCDetails? = mutatedArgs["awc"] as? MobileReaderDetails.AWCDetails
             // If details(AWC/NMI) null OR NMISecKey & any of AWC cred is Blank, then initialize SDK and return an error to warn user
             if ((updatedAWCDetails == null && updatedNMIDetails == null) ||
-                ( updatedNMIDetails?.securityKey == "" &&  ( updatedAWCDetails?.terminalId == "" || updatedAWCDetails?.terminalSecret == "") ) ){
+                ( updatedNMIDetails?.securityKey.isNullOrBlank() &&  ( updatedAWCDetails?.terminalId.isNullOrBlank() || updatedAWCDetails?.terminalSecret.isNullOrBlank()) ) ){
                 initialized = true
                 error(OmniException("Could not get reader settings", "Your account does not have mobile reader credentials"))
                 return@launch

--- a/cardpresent/src/main/java/com/fattmerchant/omni/usecase/InitializeDrivers.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/usecase/InitializeDrivers.kt
@@ -17,6 +17,7 @@ internal class InitializeDrivers(
     class InitializeDriversException(message: String? = null) : OmniException("Could not initialize drivers", message) {
         companion object {
             val NoMobileReadersFound = InitializeDriversException("Couldn't find any mobile readers")
+            val InvalidReaderCredentials = InitializeDriversException("Your account has invalid mobile reader credentials")
         }
     }
 
@@ -33,6 +34,8 @@ internal class InitializeDrivers(
             } catch (e: Throwable) {
                 if (e is OmniException) {
                     error = e
+                } else {
+                    error = InitializeDriversException.InvalidReaderCredentials
                 }
                 false
             }


### PR DESCRIPTION
## **[MOB-1247](https://fattmerchant.atlassian.net/browse/MOB-1247)**
> **Android SDK | Should be able to initialize without mobile reader credentials**
## What did I do?
* Updated initilization flow for SDK
* SDK now initilizied whenever merchant's data available
* Tokenization could be done independently from the reader credentials (either exist or invalid or not at all)
---
## PR notes contain:
* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)
## PR Checklist:
* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
