### PR TITLE
feat(PHO-4990): Update user-facing text for BBPOS swipe removal and align error events with NMI

### DIFF
--- a/cardpresent/build.gradle.kts
+++ b/cardpresent/build.gradle.kts
@@ -12,7 +12,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "com.github.fattmerchantorg"
                 artifactId = "cardpresent"
-                version = "2.7.2"
+                version = "2.7.4"
             }
         }
     }

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionUpdate.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionUpdate.kt
@@ -19,7 +19,7 @@ open class TransactionUpdate(val value: String, val userFriendlyMessage: String?
         val PromptInsertSwipeTap = TransactionUpdate("Prompt Insert Swipe Tap Card", "Please tap or insert card")
 
         /** Request card be swiped */
-        val PromptSwipeCard = TransactionUpdate("Prompt Swipe Card", "Please insert card")
+        val PromptSwipeCard = TransactionUpdate("Prompt Swipe Card", "Please tap or insert card")
 
         /** Card was swiped */
         val CardSwiped = TransactionUpdate("Card Swiped")

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionUpdate.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionUpdate.kt
@@ -10,7 +10,7 @@ open class TransactionUpdate(val value: String, val userFriendlyMessage: String?
 
     companion object {
         /** Request card be swiped or inserted */
-        val PromptInsertSwipeCard = TransactionUpdate("Prompt Insert Swipe Card", "Please insert card")
+        val PromptInsertSwipeCard = TransactionUpdate("Prompt Insert Swipe Card", "Please tap or insert card")
 
         /** Request card be inserted */
         val PromptInsertCard = TransactionUpdate("Prompt Insert Card", "Please insert card")

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionUpdate.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/TransactionUpdate.kt
@@ -10,16 +10,16 @@ open class TransactionUpdate(val value: String, val userFriendlyMessage: String?
 
     companion object {
         /** Request card be swiped or inserted */
-        val PromptInsertSwipeCard = TransactionUpdate("Prompt Insert Swipe Card", "Please insert or swipe card")
+        val PromptInsertSwipeCard = TransactionUpdate("Prompt Insert Swipe Card", "Please insert card")
 
         /** Request card be inserted */
         val PromptInsertCard = TransactionUpdate("Prompt Insert Card", "Please insert card")
 
         /** Request card be swiped, inserted, or tapped */
-        val PromptInsertSwipeTap = TransactionUpdate("Prompt Insert Swipe Tap Card", "Please insert, tap, or swipe card")
+        val PromptInsertSwipeTap = TransactionUpdate("Prompt Insert Swipe Tap Card", "Please tap or insert card")
 
         /** Request card be swiped */
-        val PromptSwipeCard = TransactionUpdate("Prompt Swipe Card", "Please swipe card")
+        val PromptSwipeCard = TransactionUpdate("Prompt Swipe Card", "Please insert card")
 
         /** Card was swiped */
         val CardSwiped = TransactionUpdate("Card Swiped")
@@ -28,7 +28,7 @@ open class TransactionUpdate(val value: String, val userFriendlyMessage: String?
         val CardInserted = TransactionUpdate("Card Inserted")
 
         /** Card Swipe error */
-        val CardSwipeError = TransactionUpdate("Card Swipe Error", "Card swipe error. Please try again")
+        val CardSwipeError = TransactionUpdate("Card Swipe Error", "Card read error. Please try again")
 
         /** Request card be removed */
         val PromptRemoveCard = TransactionUpdate("Prompt Remove Card", "Please remove card")

--- a/cardpresent/src/main/java/com/fattmerchant/omni/data/UserNotification.kt
+++ b/cardpresent/src/main/java/com/fattmerchant/omni/data/UserNotification.kt
@@ -20,16 +20,16 @@ open class UserNotification(var value: String, val userFriendlyMessage: String? 
         val PresentOneCardOnly = UserNotification("Prompt User Present One Card Only", "Please only present one card.")
 
         /** Indicates that fallback to Swipe has occurred */
-        val FallbackSwipeCard = UserNotification("Prompt User Fallback Swipe Card", "Please swipe your card.")
+        val FallbackSwipeCard = UserNotification("Prompt User Fallback Swipe Card", "Please insert your card.")
 
         /** Indicates that fallforward to Swipe has occurred */
-        val FallforwardSwipeCard = UserNotification("Prompt User Fallforward Swipe Card", "Please swipe your card.")
+        val FallforwardSwipeCard = UserNotification("Prompt User Fallforward Swipe Card", "Please insert your card.")
 
         /** Indicates that fallforward to Insert has occurred */
         val FallforwardInsertCard = UserNotification("Prompt User Fallforward Insert Card", "Please insert your card.")
 
         /** Indicates that fallforward to Insert/Swipe has occurred */
-        val FallforwardInsertSwipeCard = UserNotification("Prompt User Fallforward Insert Swipe Card", "Please insert or swipe your card.")
+        val FallforwardInsertSwipeCard = UserNotification("Prompt User Fallforward Insert Swipe Card", "Please insert your card.")
 
         /** Indicates that the card should be tried again */
         val TryCardAgain = UserNotification("Prompt User Try Card Again", "Please try your card again.")


### PR DESCRIPTION
## **[Ticket PHO-4990](https://staxpayments.atlassian.net/browse/PHO-4990)**
> **Update user-facing text for BBPOS swipe removal and align error events with NMI*
## What did I do?
* Updated all mobile reader prompts to ensure "swipe" is no longer listed as an option for mobile reader payments as a bandaid for user-facing text determined by transactionUpdateListener events.
* Did not update event titles at this time, end users may key off of them and a follow up ticket will be created to catalog existing transactionupdatelistener events and use it to remove all "swipe" related events as well as to update docs accordingly and ensure end users know these values are changing (so they can update their code before updating to the SDK version containing the changes.)

---
## PR Checklist:
* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I requested a peer review
